### PR TITLE
fix: make bitflags macro publicly accessible from generated bindings

### DIFF
--- a/rust/rust_wasm_component_bindgen.bzl
+++ b/rust/rust_wasm_component_bindgen.bzl
@@ -160,9 +160,9 @@ pub mod wit_bindgen {
 
         // Bitflags module for WASI interfaces
         pub mod bitflags {
-            // Re-export bitflags macro without #[macro_export]
+            // Re-export bitflags macro for public access from other crates
             // Generated code expects: crate::wit_bindgen::rt::bitflags::bitflags!
-            pub(crate) use bitflags;
+            pub use bitflags::bitflags;
         }
     }
 }
@@ -254,9 +254,9 @@ pub mod wit_bindgen {
 
         // Bitflags module for WASI interfaces
         pub mod bitflags {
-            // Re-export bitflags macro without #[macro_export]
+            // Re-export bitflags macro for public access from other crates
             // Generated code expects: crate::wit_bindgen::rt::bitflags::bitflags!
-            pub(crate) use bitflags;
+            pub use bitflags::bitflags;
         }
     }
 }


### PR DESCRIPTION
## Problem

The bitflags macro in the embedded wit_bindgen runtime was using `pub(crate)` visibility, which made it only accessible within the generated bindings crate itself. This prevented external crates that depend on the generated bindings from accessing the macro when they use WASI filesystem interfaces.

## Solution

Changed `pub(crate) use bitflags;` to `pub use bitflags::bitflags;` in both wrapper modes:
- Native-guest wrapper (lines 161-166)
- Guest wrapper (lines 255-260)

This properly exports the bitflags macro so downstream crates can access it through the expected path: `crate::wit_bindgen::rt::bitflags::bitflags!`

## Testing

Verified builds succeed for:
- `//examples/basic:hello_component_bindings_host` - native-guest mode bindings
- `//tools/checksum_updater_wasm:checksum_updater_wasm_component` - WASM component using WASI filesystem interfaces (wasi:filesystem/types@0.2.0)

Both targets compile without "could not find bitflags in rt" errors.

## Impact

This fixes the visibility issue for any external crate that:
1. Depends on generated bindings from `rust_wasm_component_bindgen`
2. Needs to use WASI filesystem interfaces (DescriptorFlags, PathFlags, OpenFlags)