### PR TITLE
fix(cpp): use reactor exec-model for library components

### DIFF
--- a/.github/workflows/integration-examples.yml
+++ b/.github/workflows/integration-examples.yml
@@ -149,19 +149,20 @@ jobs:
       - name: Setup integration test
         working-directory: examples
         run: |
-          # Override MODULE.bazel to use local rules checkout
-          cat >> MODULE.bazel << 'EOF'
+          # Replace git_override with local_path_override between markers
+          sed -i '/RULES_WASM_COMPONENT_OVERRIDE_START/,/RULES_WASM_COMPONENT_OVERRIDE_END/c\
+          # RULES_WASM_COMPONENT_OVERRIDE_START\
+          local_path_override(\
+              module_name = "rules_wasm_component",\
+              path = "../rules_wasm_component",\
+          )\
+          # RULES_WASM_COMPONENT_OVERRIDE_END' MODULE.bazel
 
-          # Integration test override - use PR branch
-          local_path_override(
-              module_name = "rules_wasm_component",
-              path = "../rules_wasm_component",
-          )
-          EOF
+          echo "=== MODULE.bazel override block ==="
+          sed -n '/OVERRIDE_START/,/OVERRIDE_END/p' MODULE.bazel
 
           echo "=== Testing against PR branch ==="
           cd ../rules_wasm_component && git log -1 --oneline
-          echo ""
 
       - name: Install Bazelisk
         run: |

--- a/cpp/defs.bzl
+++ b/cpp/defs.bzl
@@ -216,6 +216,7 @@ def _cpp_component_impl(ctx):
 
     # Basic compiler flags for Preview2
     compile_args.add("--target=wasm32-wasip2")
+    compile_args.add("-mexec-model=reactor")  # Library component, not CLI
 
     # Build sysroot path from toolchain repository for external compatibility
     if sysroot_files and sysroot_files.files:
@@ -522,6 +523,7 @@ def _cpp_component_impl(ctx):
             "name": ctx.label.name,
             "language": ctx.attr.language,
             "target": "wasm32-wasip2",
+            "exec_model": "reactor",
             "wasi_sdk": True,
             "toolchain": "wasi-sdk",
             "cxx_std": ctx.attr.cxx_std if ctx.attr.cxx_std else None,

--- a/cpp/private/cpp_wasm_binary.bzl
+++ b/cpp/private/cpp_wasm_binary.bzl
@@ -110,6 +110,7 @@ def _cpp_wasm_binary_impl(ctx):
 
     # Basic compiler flags for WASI Preview 2
     compile_args.add("--target=wasm32-wasip2")
+    compile_args.add("-mexec-model=command")  # CLI executable with main()
 
     # Resolve sysroot path
     if sysroot_files and sysroot_files.files:
@@ -237,6 +238,7 @@ def _cpp_wasm_binary_impl(ctx):
             "name": ctx.label.name,
             "language": ctx.attr.language,
             "target": "wasm32-wasip2",
+            "exec_model": "command",
             "wasi_sdk": True,
             "toolchain": "wasi-sdk",
             "cxx_std": ctx.attr.cxx_std if ctx.attr.cxx_std else None,


### PR DESCRIPTION
## Summary

- Add `-mexec-model=reactor` to `cpp_component` compilation (library components)
- Add `-mexec-model=command` to `cpp_wasm_binary` compilation (CLI executables)
- Add `exec_model` to WasmComponentInfo metadata for introspection

## Problem

`cpp_component` was incorrectly producing command-mode components that:
- Export `wasi:cli/run@0.2.0` (CLI interface, not library)
- Expect a `main()` function causing `undefined_weak:main` warnings
- Cannot be composed with other components

## Root Cause

Both `cpp_component` and `cpp_wasm_binary` used identical clang invocations without specifying `-mexec-model`. WASI SDK defaults to command mode.

## Solution

| Rule | Purpose | exec-model | Entry Point |
|------|---------|------------|-------------|
| `cpp_component` | Library component | `reactor` | `_initialize` |
| `cpp_wasm_binary` | CLI executable | `command` | `_start` (main) |

## Test plan

- [x] Build `//examples/cpp_component/simple_calculator:simple_calculator`
- [x] Verify component exports with `wasm-tools component wit` - no `wasi:cli/run`
- [x] Build `//test/cpp_binary:hello_cpp`
- [x] Run with wasmtime - outputs "Hello from cpp_wasm_binary!"

Fixes #302