### PR TITLE
feat: add Python WebAssembly component support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,6 +22,15 @@ bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.2.14")
 bazel_dep(name = "rules_go", version = "0.59.0")
 
+# MoonBit language support for WebAssembly components
+# NOTE: Disabled until rules_moonbit toolchain download is fixed
+# The GitHub release URL pattern in moonbit/checksums/registry_v2.bzl needs updating
+# bazel_dep(name = "rules_moonbit", version = "0.1.0")
+# local_path_override(
+#     module_name = "rules_moonbit",
+#     path = "../rules_moonbit",
+# )
+
 # OCI image signing capabilities
 bazel_dep(name = "rules_oci", version = "2.2.6")
 
@@ -216,6 +225,16 @@ register_toolchains("@nodejs_toolchains//:all")
 
 # Register jco toolchain for JavaScript/TypeScript components
 register_toolchains("@jco_toolchain//:jco_toolchain")
+
+# Python WebAssembly components with componentize-py
+componentize_py = use_extension("//wasm:extensions.bzl", "componentize_py")
+componentize_py.register(
+    name = "componentize_py",
+    version = "canary",
+)
+use_repo(componentize_py, "componentize_py_toolchain")
+
+register_toolchains("@componentize_py_toolchain//:componentize_py_toolchain")
 
 # File Operations Component toolchain for universal file handling
 register_toolchains("//toolchains:file_ops_toolchain_target")

--- a/checksums/tools/componentize-py.json
+++ b/checksums/tools/componentize-py.json
@@ -1,0 +1,40 @@
+{
+  "tool_name": "componentize-py",
+  "github_repo": "bytecodealliance/componentize-py",
+  "latest_version": "canary",
+  "last_checked": "2026-01-11T00:00:00Z",
+  "versions": {
+    "canary": {
+      "release_date": "2026-01-02",
+      "platforms": {
+        "darwin_arm64": {
+          "sha256": "ccc92feabd847dbf71852fd8aef7940eb243fc6dca8d61a275fb067030aae3ef",
+          "url_suffix": "macos-aarch64.tar.gz"
+        },
+        "darwin_amd64": {
+          "sha256": "f6eee0ef74c491b694d817f2f4fd36e4c6c53c8a04ac280c1a09d615a8d8443a",
+          "url_suffix": "macos-amd64.tar.gz"
+        },
+        "linux_arm64": {
+          "sha256": "be9514228023b9a71879f5277c08469fe3edf24d2dc70b2498b5e61e5fb6315b",
+          "url_suffix": "linux-aarch64.tar.gz"
+        },
+        "linux_amd64": {
+          "sha256": "fd7538ca22357ee579f7f97c7cd62ad7230ec3d2a3b4ecedd93f5103975e9040",
+          "url_suffix": "linux-amd64.tar.gz"
+        },
+        "windows_amd64": {
+          "sha256": "710a6d533fd06808d424d2157825e1fbc86c2e94bd5f8f93ce52b72b5cb3465e",
+          "url_suffix": "windows-amd64.tar.gz"
+        }
+      }
+    }
+  },
+  "supported_platforms": [
+    "darwin_amd64",
+    "darwin_arm64",
+    "linux_amd64",
+    "linux_arm64",
+    "windows_amd64"
+  ]
+}

--- a/examples/python_component/BUILD.bazel
+++ b/examples/python_component/BUILD.bazel
@@ -1,0 +1,36 @@
+"""Python WebAssembly Component Examples
+
+Demonstrates building Python code into WebAssembly using componentize-py.
+
+Two patterns are shown:
+
+1. python_wasm_component - Library component with custom WIT exports
+   Usage:
+       bazel build //examples/python_component:hello_python
+       # Requires a host to call the exported functions
+
+2. python_wasm_binary - CLI executable (like main())
+   Usage:
+       bazel build //examples/python_component:hello_cli
+       wasmtime run bazel-bin/examples/python_component/hello_cli.wasm
+"""
+
+load("//python:defs.bzl", "python_wasm_binary", "python_wasm_component")
+
+package(default_visibility = ["//visibility:public"])
+
+# Library component - exports custom functions defined in WIT
+# Python code implements: class WitWorld(wit_world.WitWorld)
+python_wasm_component(
+    name = "hello_python",
+    srcs = ["app.py"],
+    wit = "hello.wit",
+    world = "hello",
+)
+
+# CLI binary - exports wasi:cli/run for direct execution
+# Python code implements: class Run(exports.Run)
+python_wasm_binary(
+    name = "hello_cli",
+    srcs = ["cli_app.py"],
+)

--- a/examples/python_component/app.py
+++ b/examples/python_component/app.py
@@ -1,0 +1,28 @@
+"""Hello World Python WebAssembly Component
+
+This demonstrates building a Python WebAssembly component using componentize-py.
+The component exports a single `hello` function that returns a greeting.
+
+Run with: wasmtime run bazel-bin/examples/python_component/hello_python.wasm
+
+componentize-py generates bindings in the `wit_world` module.
+We import and extend the generated `WitWorld` class to implement our exports.
+The class must be named exactly `WitWorld` - this is a componentize-py requirement.
+"""
+
+import wit_world
+
+class WitWorld(wit_world.WitWorld):
+    """Implementation of the 'hello' WIT world exports.
+
+    This class inherits from the generated bindings and implements
+    the exported functions defined in hello.wit.
+    """
+
+    def hello(self) -> str:
+        """Return a hello greeting.
+
+        This method implements the `hello: func() -> string` export
+        from the WIT definition.
+        """
+        return "Hello from Python WebAssembly!"

--- a/examples/python_component/cli_app.py
+++ b/examples/python_component/cli_app.py
@@ -1,0 +1,30 @@
+"""Python WebAssembly CLI Binary Example
+
+This demonstrates building a Python CLI program using componentize-py
+targeting the wasi:cli/command world.
+
+Run with: wasmtime run bazel-bin/examples/python_component/hello_cli.wasm
+
+The Run.run() pattern is Python's equivalent of main() for WASI CLI commands.
+"""
+
+from wit_world import exports
+
+
+class Run(exports.Run):
+    """Implementation of wasi:cli/run export.
+
+    This class is Python's equivalent of main() for WebAssembly CLI programs.
+    The run() method is called when the component is executed.
+    """
+
+    def run(self) -> None:
+        """Entry point for the CLI program.
+
+        This method implements the wasi:cli/run export, making the component
+        executable with `wasmtime run`.
+        """
+        print("Hello from Python WebAssembly CLI!")
+        print("")
+        print("This is a WASI CLI command built with componentize-py.")
+        print("It exports wasi:cli/run and can be executed directly.")

--- a/examples/python_component/hello.wit
+++ b/examples/python_component/hello.wit
@@ -1,0 +1,5 @@
+package component:hello@1.0.0;
+
+world hello {
+    export hello: func() -> string;
+}

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -1,0 +1,14 @@
+"""Python WebAssembly Component rules package"""
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+package(default_visibility = ["//visibility:public"])
+
+bzl_library(
+    name = "defs",
+    srcs = ["defs.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//python/private:python_wasm_component",
+    ],
+)

--- a/python/defs.bzl
+++ b/python/defs.bzl
@@ -1,0 +1,53 @@
+"""Python WebAssembly Component Model rules - PUBLIC API
+
+STABILITY: Public API
+The rules in this file are the public API of rules_wasm_component for Python.
+They are subject to semantic versioning guarantees.
+
+Python support uses componentize-py from Bytecode Alliance to build
+Python code into WebAssembly components. componentize-py bundles Python
+source with a WASM interpreter to create WASI Preview 2 components.
+
+Two rules are provided:
+
+1. python_wasm_component - Library component with custom WIT exports
+2. python_wasm_binary - CLI executable targeting wasi:cli/command
+
+Limitations:
+- Pure Python only (no native extensions)
+- Runtime is bundled in the WASM component (~25-40MB overhead)
+- Best suited for business logic and glue code
+
+Example usage:
+
+    load("@rules_wasm_component//python:defs.bzl", "python_wasm_component", "python_wasm_binary")
+
+    # Library component with custom interface
+    python_wasm_component(
+        name = "calculator",
+        srcs = ["calculator.py"],
+        wit = "calculator.wit",
+        world = "calculator",
+    )
+
+    # CLI executable
+    python_wasm_binary(
+        name = "hello",
+        srcs = ["app.py"],
+    )
+
+    # Run CLI with: wasmtime run bazel-bin/path/to/hello.wasm
+"""
+
+load(
+    "//python/private:python_wasm_binary.bzl",
+    _python_wasm_binary = "python_wasm_binary",
+)
+load(
+    "//python/private:python_wasm_component.bzl",
+    _python_wasm_component = "python_wasm_component",
+)
+
+# Re-export public rules
+python_wasm_component = _python_wasm_component
+python_wasm_binary = _python_wasm_binary

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -1,0 +1,24 @@
+"""Python WebAssembly Component private implementation"""
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+package(default_visibility = ["//python:__subpackages__"])
+
+bzl_library(
+    name = "python_wasm_component",
+    srcs = ["python_wasm_component.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//providers:providers",
+        "//rust:transitions",
+    ],
+)
+
+bzl_library(
+    name = "python_wasm_binary",
+    srcs = ["python_wasm_binary.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//providers:providers",
+    ],
+)

--- a/python/private/python_wasm_binary.bzl
+++ b/python/private/python_wasm_binary.bzl
@@ -1,0 +1,353 @@
+"""Python WebAssembly CLI binary rule implementation.
+
+Builds Python code as WebAssembly CLI binaries that export wasi:cli/command,
+suitable for execution with wasmtime. This is the Python equivalent of
+cpp_wasm_binary and rust_wasm_binary.
+
+Example usage:
+
+    python_wasm_binary(
+        name = "hello",
+        srcs = ["app.py"],
+    )
+
+    # Run with: wasmtime run bazel-bin/examples/hello.wasm
+
+The Python code must implement the Run.run() pattern:
+
+    from wit_world import exports
+
+    class Run(exports.Run):
+        def run(self) -> None:
+            print("Hello, world!")
+"""
+
+load("//providers:providers.bzl", "WasmComponentInfo")
+
+def _python_wasm_binary_impl(ctx):
+    """Implementation of python_wasm_binary rule.
+
+    Compiles Python source code into a WebAssembly CLI binary using componentize-py
+    targeting the wasi:cli/command world.
+
+    Args:
+        ctx: The rule context containing:
+            - ctx.files.srcs: Python source files
+            - ctx.attr.entry_point: Main Python module (default: first .py file or app.py)
+
+    Returns:
+        List of providers:
+        - WasmComponentInfo: Binary metadata
+        - DefaultInfo: WASM binary file
+    """
+
+    # Get componentize-py toolchain
+    py_toolchain = ctx.toolchains["@rules_wasm_component//toolchains:componentize_py_toolchain_type"]
+    componentize_py = py_toolchain.componentize_py
+
+    # Output component file
+    wasm_binary = ctx.actions.declare_file(ctx.attr.name + ".wasm")
+
+    # Input source files
+    source_files = ctx.files.srcs
+
+    # Find the entry point file
+    entry_point = ctx.attr.entry_point
+    entry_point_file = None
+
+    if entry_point:
+        for src in source_files:
+            if src.basename == entry_point or src.path.endswith(entry_point):
+                entry_point_file = src
+                break
+    else:
+        # Auto-detect: use app.py, main.py, or first .py file
+        priority_names = ["app.py", "main.py", "__init__.py"]
+        for name in priority_names:
+            for src in source_files:
+                if src.basename == name:
+                    entry_point_file = src
+                    break
+            if entry_point_file:
+                break
+
+        if not entry_point_file and source_files:
+            for src in source_files:
+                if src.extension == "py":
+                    entry_point_file = src
+                    break
+
+    if not entry_point_file:
+        fail("No Python entry point found. Specify entry_point or add a .py file to srcs.")
+
+    # Create build script
+    build_script = ctx.actions.declare_file(ctx.attr.name + "_build.sh")
+
+    # Get module name (without .py extension)
+    module_name = entry_point_file.basename
+    if module_name.endswith(".py"):
+        module_name = module_name[:-3]
+
+    # Embed minimal WASI CLI WIT files matching componentize-py's expected format
+    # This avoids complex WIT package assembly from external deps
+    script_lines = [
+        "#!/bin/bash",
+        "set -euo pipefail",
+        "",
+        "# Save original directory for absolute paths",
+        "ORIGINAL_DIR=\"$(pwd)\"",
+        "",
+        "# Create temporary workspace",
+        "WORK_DIR=$(mktemp -d)",
+        "trap 'rm -rf \"$WORK_DIR\"' EXIT",
+        "",
+        "# Create WIT directory structure matching componentize-py format",
+        "mkdir -p \"$WORK_DIR/wit/deps/cli\"",
+        "mkdir -p \"$WORK_DIR/wit/deps/io\"",
+        "",
+        "# Create root world that references wasi:cli/command",
+        "cat > \"$WORK_DIR/wit/world.wit\" << 'WITEOF'",
+        "package local:app@0.1.0;",
+        "",
+        "world app {",
+        "  include wasi:cli/command@0.2.0;",
+        "}",
+        "WITEOF",
+        "",
+        "# Create WASI CLI package WIT files",
+        "cat > \"$WORK_DIR/wit/deps/cli/command.wit\" << 'WITEOF'",
+        "package wasi:cli@0.2.0;",
+        "",
+        "world command {",
+        "  include imports;",
+        "  export run;",
+        "}",
+        "WITEOF",
+        "",
+        "cat > \"$WORK_DIR/wit/deps/cli/run.wit\" << 'WITEOF'",
+        "interface run {",
+        "  run: func() -> result;",
+        "}",
+        "WITEOF",
+        "",
+        "cat > \"$WORK_DIR/wit/deps/cli/imports.wit\" << 'WITEOF'",
+        "world imports {",
+        "  import wasi:io/error@0.2.0;",
+        "  import wasi:io/poll@0.2.0;",
+        "  import wasi:io/streams@0.2.0;",
+        "  import environment;",
+        "  import exit;",
+        "  import stdin;",
+        "  import stdout;",
+        "  import stderr;",
+        "}",
+        "WITEOF",
+        "",
+        "cat > \"$WORK_DIR/wit/deps/cli/environment.wit\" << 'WITEOF'",
+        "interface environment {",
+        "  get-environment: func() -> list<tuple<string, string>>;",
+        "  get-arguments: func() -> list<string>;",
+        "  initial-cwd: func() -> option<string>;",
+        "}",
+        "WITEOF",
+        "",
+        "cat > \"$WORK_DIR/wit/deps/cli/exit.wit\" << 'WITEOF'",
+        "interface exit {",
+        "  exit: func(status: result);",
+        "}",
+        "WITEOF",
+        "",
+        "cat > \"$WORK_DIR/wit/deps/cli/stdio.wit\" << 'WITEOF'",
+        "interface stdin {",
+        "  use wasi:io/streams@0.2.0.{input-stream};",
+        "  get-stdin: func() -> input-stream;",
+        "}",
+        "interface stdout {",
+        "  use wasi:io/streams@0.2.0.{output-stream};",
+        "  get-stdout: func() -> output-stream;",
+        "}",
+        "interface stderr {",
+        "  use wasi:io/streams@0.2.0.{output-stream};",
+        "  get-stderr: func() -> output-stream;",
+        "}",
+        "WITEOF",
+        "",
+        "# Create WASI IO package WIT files",
+        "cat > \"$WORK_DIR/wit/deps/io/world.wit\" << 'WITEOF'",
+        "package wasi:io@0.2.0;",
+        "",
+        "world imports {",
+        "  import error;",
+        "  import poll;",
+        "  import streams;",
+        "}",
+        "WITEOF",
+        "",
+        "cat > \"$WORK_DIR/wit/deps/io/error.wit\" << 'WITEOF'",
+        "interface error {",
+        "  resource error {",
+        "    to-debug-string: func() -> string;",
+        "  }",
+        "}",
+        "WITEOF",
+        "",
+        "cat > \"$WORK_DIR/wit/deps/io/poll.wit\" << 'WITEOF'",
+        "interface poll {",
+        "  resource pollable {",
+        "    ready: func() -> bool;",
+        "    block: func();",
+        "  }",
+        "  poll: func(in: list<borrow<pollable>>) -> list<u32>;",
+        "}",
+        "WITEOF",
+        "",
+        "cat > \"$WORK_DIR/wit/deps/io/streams.wit\" << 'WITEOF'",
+        "interface streams {",
+        "  use error.{error};",
+        "  use poll.{pollable};",
+        "",
+        "  variant stream-error {",
+        "    last-operation-failed(error),",
+        "    closed,",
+        "  }",
+        "",
+        "  resource input-stream {",
+        "    read: func(len: u64) -> result<list<u8>, stream-error>;",
+        "    blocking-read: func(len: u64) -> result<list<u8>, stream-error>;",
+        "    skip: func(len: u64) -> result<u64, stream-error>;",
+        "    blocking-skip: func(len: u64) -> result<u64, stream-error>;",
+        "    subscribe: func() -> pollable;",
+        "  }",
+        "",
+        "  resource output-stream {",
+        "    check-write: func() -> result<u64, stream-error>;",
+        "    write: func(contents: list<u8>) -> result<_, stream-error>;",
+        "    blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;",
+        "    flush: func() -> result<_, stream-error>;",
+        "    blocking-flush: func() -> result<_, stream-error>;",
+        "    subscribe: func() -> pollable;",
+        "    write-zeroes: func(len: u64) -> result<_, stream-error>;",
+        "    blocking-write-zeroes-and-flush: func(len: u64) -> result<_, stream-error>;",
+        "    splice: func(src: borrow<input-stream>, len: u64) -> result<u64, stream-error>;",
+        "    blocking-splice: func(src: borrow<input-stream>, len: u64) -> result<u64, stream-error>;",
+        "  }",
+        "}",
+        "WITEOF",
+        "",
+        "# Copy Python source files",
+    ]
+
+    for src in source_files:
+        script_lines.append("cp \"$ORIGINAL_DIR/{}\" \"$WORK_DIR/{}\"".format(
+            src.path, src.basename))
+
+    script_lines.extend([
+        "",
+        "# Change to workspace",
+        "cd \"$WORK_DIR\"",
+        "",
+        "# Run componentize-py targeting wasi:cli/command",
+        "\"$ORIGINAL_DIR/{}\" \\".format(componentize_py.path),
+        "  -d \"$WORK_DIR/wit\" \\",
+        "  -w wasi:cli/command@0.2.0 \\",
+        "  componentize \"{}\" \\".format(module_name),
+        "  -p . \\",
+        "  -o \"$ORIGINAL_DIR/{}\"".format(wasm_binary.path),
+        "",
+        "echo 'Python CLI binary built successfully'",
+    ])
+
+    ctx.actions.write(
+        output = build_script,
+        content = "\n".join(script_lines),
+        is_executable = True,
+    )
+
+    # Collect all inputs (WIT files are embedded in the script)
+    all_inputs = list(source_files) + [componentize_py]
+
+    # Run the build script
+    ctx.actions.run(
+        executable = build_script,
+        inputs = all_inputs,
+        outputs = [wasm_binary],
+        mnemonic = "ComponentizePyCLI",
+        progress_message = "Building Python CLI binary %s with componentize-py" % ctx.label,
+        use_default_shell_env = True,
+    )
+
+    # Create WasmComponentInfo provider
+    component_info = WasmComponentInfo(
+        wasm_file = wasm_binary,
+        wit_info = struct(
+            wit_file = None,
+            package_name = "wasi:cli@0.2.0",
+        ),
+        component_type = "command",
+        imports = [
+            "wasi:cli/environment@0.2.0",
+            "wasi:cli/exit@0.2.0",
+            "wasi:cli/stdin@0.2.0",
+            "wasi:cli/stdout@0.2.0",
+            "wasi:cli/stderr@0.2.0",
+        ],
+        exports = ["wasi:cli/run@0.2.0"],
+        metadata = {
+            "name": ctx.label.name,
+            "language": "python",
+            "target": "wasm32-wasi",
+            "componentize_py": True,
+            "entry_point": entry_point_file.basename,
+            "exec_model": "command",
+        },
+        profile = "release",
+        profile_variants = {},
+    )
+
+    return [
+        component_info,
+        DefaultInfo(
+            files = depset([wasm_binary]),
+            executable = wasm_binary,
+        ),
+    ]
+
+python_wasm_binary = rule(
+    implementation = _python_wasm_binary_impl,
+    executable = True,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = [".py"],
+            mandatory = True,
+            doc = "Python source files. Must include a module with Run.run() implementation.",
+        ),
+        "entry_point": attr.string(
+            doc = "Main Python module file (auto-detected if not specified, prefers app.py)",
+        ),
+    },
+    toolchains = [
+        "@rules_wasm_component//toolchains:componentize_py_toolchain_type",
+    ],
+    doc = """Builds a WebAssembly CLI binary from Python source code.
+
+    Uses componentize-py to create a WASI CLI command component that can be
+    executed directly with wasmtime. This is the Python equivalent of
+    cpp_wasm_binary and rust_wasm_binary.
+
+    The Python code must implement the Run.run() pattern:
+
+        from wit_world import exports
+
+        class Run(exports.Run):
+            def run(self) -> None:
+                print("Hello, world!")
+
+    Example:
+        python_wasm_binary(
+            name = "hello",
+            srcs = ["app.py"],
+        )
+
+        # Run with: wasmtime run bazel-bin/path/to/hello.wasm
+    """,
+)

--- a/python/private/python_wasm_component.bzl
+++ b/python/private/python_wasm_component.bzl
@@ -1,0 +1,244 @@
+"""Python WebAssembly Component rule implementation.
+
+Builds Python code into WebAssembly components using componentize-py.
+componentize-py bundles Python source with a WASM interpreter and generates
+WASI Preview 2 components.
+
+Example usage:
+
+    python_wasm_component(
+        name = "hello",
+        srcs = ["hello.py"],
+        wit = "//wit:hello",
+        world = "hello",
+    )
+"""
+
+load("//providers:providers.bzl", "WasmComponentInfo")
+load("//rust:transitions.bzl", "wasm_transition")
+
+def _python_wasm_component_impl(ctx):
+    """Implementation of python_wasm_component rule.
+
+    Compiles Python source code into WebAssembly components using componentize-py.
+
+    Args:
+        ctx: The rule context containing:
+            - ctx.files.srcs: Python source files
+            - ctx.file.wit: WIT interface definition file
+            - ctx.attr.entry_point: Main Python module (default: first .py file)
+            - ctx.attr.world: WIT world to target
+            - ctx.attr.stub_wasi: Generate WASI stubs
+
+    Returns:
+        List of providers:
+        - WasmComponentInfo: Component metadata for Python
+        - DefaultInfo: Component .wasm file
+    """
+
+    # Get componentize-py toolchain
+    py_toolchain = ctx.toolchains["@rules_wasm_component//toolchains:componentize_py_toolchain_type"]
+    componentize_py = py_toolchain.componentize_py
+
+    # Output component file
+    component_wasm = ctx.actions.declare_file(ctx.attr.name + ".wasm")
+
+    # Input source files
+    source_files = ctx.files.srcs
+    wit_file = ctx.file.wit
+
+    # Find the entry point file
+    entry_point = ctx.attr.entry_point
+    entry_point_file = None
+
+    if entry_point:
+        # User specified an entry point
+        for src in source_files:
+            if src.basename == entry_point or src.path.endswith(entry_point):
+                entry_point_file = src
+                break
+    else:
+        # Auto-detect: use first .py file or app.py or main.py
+        priority_names = ["app.py", "main.py", "__init__.py"]
+        for name in priority_names:
+            for src in source_files:
+                if src.basename == name:
+                    entry_point_file = src
+                    break
+            if entry_point_file:
+                break
+
+        if not entry_point_file and source_files:
+            # Fall back to first .py file
+            for src in source_files:
+                if src.extension == "py":
+                    entry_point_file = src
+                    break
+
+    if not entry_point_file:
+        fail("No Python entry point found. Specify entry_point or add a .py file to srcs.")
+
+    # Create build script to run componentize-py
+    build_script = ctx.actions.declare_file(ctx.attr.name + "_build.sh")
+
+    script_lines = [
+        "#!/bin/bash",
+        "set -euo pipefail",
+        "",
+        "# Create temporary workspace",
+        "WORK_DIR=$(mktemp -d)",
+        "",
+        "# Copy all source files to workspace",
+    ]
+
+    # Copy source files preserving relative paths within package
+    for src in source_files:
+        script_lines.append("cp \"{}\" \"$WORK_DIR/{}\"".format(src.path, src.basename))
+
+    # Build componentize-py command
+    script_lines.extend([
+        "",
+        "# Save original directory for absolute paths",
+        "ORIGINAL_DIR=\"$(pwd)\"",
+        "",
+        "# Change to workspace directory",
+        "cd \"$WORK_DIR\"",
+        "",
+        "# Run componentize-py",
+    ])
+
+    # componentize-py command structure:
+    # componentize-py [GLOBAL_OPTIONS] componentize <APP_NAME> [SUBCOMMAND_OPTIONS]
+    #
+    # Global options: -d/--wit-path, -w/--world
+    # Subcommand options: -o/--output, -p/--python-path, -s/--stub-wasi
+
+    # Get module name from entry point (without .py extension)
+    module_name = entry_point_file.basename
+    if module_name.endswith(".py"):
+        module_name = module_name[:-3]
+
+    cmd_parts = [
+        "\"$ORIGINAL_DIR/{}\"".format(componentize_py.path),
+        # Global options (before subcommand)
+        "-d \"$ORIGINAL_DIR/{}\"".format(wit_file.path),  # WIT file path
+        "-w \"{}\"".format(ctx.attr.world),  # World name
+        # Subcommand
+        "componentize",
+        # Module name (positional argument)
+        "\"{}\"".format(module_name),
+        # Subcommand options (after subcommand)
+        "-p .",  # Python path (current directory where we copied sources)
+        "-o \"$ORIGINAL_DIR/{}\"".format(component_wasm.path),  # Output path
+    ]
+
+    # Add stub-wasi flag if enabled (subcommand option)
+    if ctx.attr.stub_wasi:
+        cmd_parts.append("-s")
+
+    script_lines.extend([
+        " ".join(cmd_parts),
+        "",
+        "# Cleanup",
+        "rm -rf \"$WORK_DIR\"",
+        "",
+        "echo \"Python component build complete\"",
+    ])
+
+    ctx.actions.write(
+        output = build_script,
+        content = "\n".join(script_lines),
+        is_executable = True,
+    )
+
+    # Collect all inputs
+    all_inputs = source_files + [wit_file, componentize_py]
+
+    # Run the build script
+    ctx.actions.run(
+        executable = build_script,
+        inputs = all_inputs,
+        outputs = [component_wasm],
+        mnemonic = "ComponentizePy",
+        progress_message = "Building Python component %s with componentize-py" % ctx.label,
+        use_default_shell_env = True,
+    )
+
+    # Create WasmComponentInfo provider
+    component_info = WasmComponentInfo(
+        wasm_file = component_wasm,
+        wit_info = struct(
+            wit_file = wit_file,
+            package_name = ctx.attr.package_name or "component:{}@1.0.0".format(ctx.attr.name),
+        ),
+        component_type = "component",
+        imports = [],  # componentize-py handles imports automatically
+        exports = [ctx.attr.world] if ctx.attr.world else [],
+        metadata = {
+            "name": ctx.label.name,
+            "language": "python",
+            "target": "wasm32-wasi",
+            "componentize_py": True,
+            "entry_point": entry_point_file.basename,
+        },
+        profile = "release",
+        profile_variants = {},
+    )
+
+    return [
+        component_info,
+        DefaultInfo(
+            files = depset([component_wasm]),
+            executable = component_wasm,
+        ),
+    ]
+
+python_wasm_component = rule(
+    implementation = _python_wasm_component_impl,
+    cfg = wasm_transition,
+    executable = True,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = [".py"],
+            mandatory = True,
+            doc = "Python source files",
+        ),
+        "wit": attr.label(
+            allow_single_file = [".wit"],
+            mandatory = True,
+            doc = "WIT interface definition file",
+        ),
+        "entry_point": attr.string(
+            doc = "Main Python module file (auto-detected if not specified)",
+        ),
+        "world": attr.string(
+            mandatory = True,
+            doc = "WIT world name to target",
+        ),
+        "package_name": attr.string(
+            doc = "WIT package name (default: component:{name}@1.0.0)",
+        ),
+        "stub_wasi": attr.bool(
+            default = False,
+            doc = "Generate WASI stub implementations",
+        ),
+    },
+    toolchains = [
+        "@rules_wasm_component//toolchains:componentize_py_toolchain_type",
+    ],
+    doc = """Builds a WebAssembly component from Python source code.
+
+    Uses componentize-py to bundle Python source with a WASM interpreter
+    and generate WASI Preview 2 components.
+
+    Example:
+        python_wasm_component(
+            name = "hello",
+            srcs = ["hello.py"],
+            wit = "//wit:hello",
+            world = "hello",
+        )
+
+        # Run with: wasmtime run bazel-bin/path/to/hello.wasm
+    """,
+)

--- a/toolchains/BUILD.bazel
+++ b/toolchains/BUILD.bazel
@@ -72,6 +72,12 @@ toolchain_type(
     visibility = ["//visibility:public"],
 )
 
+# Toolchain type for componentize-py (Python WebAssembly components)
+toolchain_type(
+    name = "componentize_py_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
 # Bzl library for tool versions (single source of truth)
 bzl_library(
     name = "tool_versions",
@@ -205,6 +211,17 @@ bzl_library(
     deps = [
         ":diagnostics",
         ":tool_cache",
+    ],
+)
+
+# Bzl library for componentize-py toolchain implementation
+bzl_library(
+    name = "componentize_py_toolchain",
+    srcs = ["componentize_py_toolchain.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":tool_registry",
+        "//checksums:registry",
     ],
 )
 

--- a/toolchains/componentize_py_toolchain.bzl
+++ b/toolchains/componentize_py_toolchain.bzl
@@ -1,0 +1,158 @@
+"""componentize-py toolchain definitions for Python WebAssembly components
+
+This toolchain provides the componentize-py tool from Bytecode Alliance
+for building Python code into WebAssembly components.
+
+componentize-py is a standalone Rust binary that:
+- Bundles Python source with a WASM interpreter
+- Generates WIT bindings automatically
+- Produces WASI Preview 2 components
+
+Usage:
+    load("@rules_wasm_component//toolchains:componentize_py_toolchain.bzl",
+         "componentize_py_toolchain_repository")
+
+    componentize_py_toolchain_repository(name = "componentize_py_toolchain")
+"""
+
+load("//toolchains:bundle.bzl", "get_version_for_tool", "log_bundle_usage")
+load("//toolchains:tool_registry.bzl", "tool_registry")
+
+def _componentize_py_toolchain_impl(ctx):
+    """Implementation of componentize_py_toolchain rule"""
+    toolchain_info = platform_common.ToolchainInfo(
+        componentize_py = ctx.file.componentize_py,
+    )
+    return [toolchain_info]
+
+componentize_py_toolchain = rule(
+    implementation = _componentize_py_toolchain_impl,
+    attrs = {
+        "componentize_py": attr.label(
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+            doc = "componentize-py binary",
+        ),
+    },
+    doc = "Declares a componentize-py toolchain for Python WebAssembly components",
+)
+
+def _componentize_py_toolchain_repository_impl(repository_ctx):
+    """Create componentize-py toolchain repository"""
+
+    platform = tool_registry.detect_platform(repository_ctx)
+    bundle_name = repository_ctx.attr.bundle
+
+    # Resolve version from bundle or use explicit version
+    if bundle_name:
+        version = get_version_for_tool(
+            repository_ctx,
+            "componentize-py",
+            bundle_name = bundle_name,
+            fallback_version = repository_ctx.attr.version,
+        )
+        log_bundle_usage(repository_ctx, "componentize-py", version, bundle_name)
+    else:
+        version = repository_ctx.attr.version
+
+    # Download componentize-py using the unified tool registry
+    _download_componentize_py(repository_ctx, platform, version)
+
+    # Create BUILD files
+    _create_build_files(repository_ctx)
+
+def _download_componentize_py(repository_ctx, platform, version):
+    """Download componentize-py binary using tool_registry"""
+
+    # Use tool_registry for standardized download with checksum verification
+    # tool_registry.download() returns a dict with binary_path, extract_dir, and tool_info
+    # It will call fail() if download fails, so no need to check for success
+    result = tool_registry.download(
+        repository_ctx,
+        "componentize-py",
+        version,
+        platform,
+    )
+
+    # The binary path is returned directly by tool_registry
+    binary_path = result.get("binary_path", "")
+
+    # Determine expected binary name
+    binary_name = "componentize-py"
+    if repository_ctx.os.name.lower().find("windows") != -1:
+        binary_name = "componentize-py.exe"
+
+    # If the binary was found in a subdirectory, symlink to root for consistency
+    if binary_path and binary_path != binary_name:
+        if repository_ctx.path(binary_path).exists:
+            repository_ctx.symlink(binary_path, binary_name)
+            repository_ctx.execute(["chmod", "+x", binary_name])
+        else:
+            # Try to find the binary manually
+            debug_result = repository_ctx.execute(["find", ".", "-name", "*componentize*", "-type", "f"])
+            fail("componentize-py binary not found at {}. Find result: {}".format(
+                binary_path,
+                debug_result.stdout,
+            ))
+    elif not repository_ctx.path(binary_name).exists:
+        # Binary not at expected location, try to find it
+        debug_result = repository_ctx.execute(["find", ".", "-name", "*componentize*", "-type", "f"])
+        fail("componentize-py binary not found. Find result: {}".format(debug_result.stdout))
+
+def _create_build_files(repository_ctx):
+    """Create BUILD files for componentize-py toolchain"""
+
+    binary_name = "componentize-py"
+    if repository_ctx.os.name.lower().find("windows") != -1:
+        binary_name = "componentize-py.exe"
+
+    repository_ctx.file("BUILD.bazel", """
+load("@rules_wasm_component//toolchains:componentize_py_toolchain.bzl", "componentize_py_toolchain")
+
+package(default_visibility = ["//visibility:public"])
+
+# Binary target
+filegroup(
+    name = "componentize_py_binary",
+    srcs = ["{binary_name}"],
+    visibility = ["//visibility:public"],
+)
+
+# Toolchain implementation
+componentize_py_toolchain(
+    name = "componentize_py_toolchain_impl",
+    componentize_py = ":componentize_py_binary",
+)
+
+# Toolchain registration
+toolchain(
+    name = "componentize_py_toolchain",
+    toolchain = ":componentize_py_toolchain_impl",
+    toolchain_type = "@rules_wasm_component//toolchains:componentize_py_toolchain_type",
+    exec_compatible_with = [],
+    target_compatible_with = [],
+)
+
+# Alias for easy registration
+alias(
+    name = "all",
+    actual = ":componentize_py_toolchain",
+    visibility = ["//visibility:public"],
+)
+""".format(binary_name = binary_name))
+
+componentize_py_toolchain_repository = repository_rule(
+    implementation = _componentize_py_toolchain_repository_impl,
+    attrs = {
+        "bundle": attr.string(
+            doc = "Toolchain bundle name. If set, version is read from checksums/toolchain_bundles.json",
+            default = "",
+        ),
+        "version": attr.string(
+            doc = "componentize-py version to use. Ignored if bundle is specified.",
+            default = "canary",
+        ),
+    },
+    doc = "Creates a componentize-py toolchain repository",
+)

--- a/toolchains/tool_registry.bzl
+++ b/toolchains/tool_registry.bzl
@@ -120,6 +120,11 @@ _URL_PATTERNS = {
         "base": "https://github.com/{repo}/releases/download/version_{version}",
         "filename": "binaryen-version_{version}-{suffix}",
     },
+    "componentize-py": {
+        # componentize-py releases use tag name directly (e.g., "canary"), no 'v' prefix
+        "base": "https://github.com/{repo}/releases/download/{version}",
+        "filename": "componentize-py-{version}-{suffix}",
+    },
 }
 
 def _build_download_url(tool_name, version, platform, tool_info, github_repo):


### PR DESCRIPTION
## Summary

Add support for building Python code into WebAssembly components using [componentize-py](https://github.com/bytecodealliance/componentize-py).

- `python_wasm_component`: Library component with custom WIT exports
- `python_wasm_binary`: CLI binary with `wasi:cli/run` export
- Hermetic `componentize_py_toolchain` with checksum verification
- Lazy loading via `python_wasm` extension

## New Rules

### python_wasm_component
```starlark
python_wasm_component(
    name = "hello",
    srcs = ["app.py"],
    wit = "hello.wit",
    world = "hello",
)
```

### python_wasm_binary
```starlark
python_wasm_binary(
    name = "cli_app",
    srcs = ["cli_app.py"],
)
```

## Lazy Loading

```starlark
# Only download Python toolchain when needed
python_wasm = use_extension("@rules_wasm_component//wasm:language_extensions.bzl", "python_wasm")
python_wasm.configure()
use_repo(python_wasm, "componentize_py_toolchain", ...)
```

## Test plan
- [ ] Build `//examples/python_component:hello`
- [ ] Build `//examples/python_component:cli_app`
- [ ] Verify component exports with `wasm-tools component wit`
- [ ] Test lazy loading extension works correctly