### PR TITLE
fix: test Windows LNK1181 LIBPATH quoting fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            ~/_bazel
+            D:\_b
             ~/AppData/Local/bazelisk
           key: ${{ runner.os }}-bazel-${{ hashFiles('MODULE.bazel', 'WORKSPACE.bazel', '**/*.bzl') }}
           restore-keys: |
@@ -350,14 +350,16 @@ jobs:
       - name: Build Core Targets
         run: |
           # Build core targets on Windows (subset of Linux/macOS)
-          # Start with basic examples that should work cross-platform
-          bazel build --keep_going -- `
+          # Use short output_base to avoid Windows MAX_PATH (260 char) limit
+          # Full paths like C:\users\..._bazel_...\execroot\...\rules_rust++rust+...\librustc_std_workspace_alloc.rlib
+          # can exceed 260 chars and cause LNK1181 errors
+          bazel --output_base=D:\_b build --keep_going -- `
             //examples/basic:hello_component `
             //rust/... `
             //providers/...
 
       - name: Run Unit Tests
-        run: bazel test --test_output=errors -- //test/unit:unit_tests
+        run: bazel --output_base=D:\_b test --test_output=errors -- //test/unit:unit_tests
 
   bcr-docker-test:
     name: BCR Docker Environment Test

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,14 +9,14 @@ module(
 # Dependencies for WebAssembly tooling
 bazel_dep(name = "rules_rust", version = "0.69.0")
 
-# Override rules_rust with upstream main at PR #3727 merge point
+# Override rules_rust with fork that fixes Windows LNK1181 LIBPATH quoting
 # Includes: 0.69.0 + .rmeta sysroot fix (#3860) + rustc_lib filegroup fix (#3727)
-# This fixes Windows LNK1181 errors with missing rlib files
-# TODO: Remove override once 0.70.0 is released with #3727 included
+#           + Windows LIBPATH quoting fix (fix/windows-libpath-quoting)
+# TODO: Remove override once fix is merged upstream and released
 git_override(
     module_name = "rules_rust",
-    commit = "6281d27f3ffdb826df90db25c1dc66a198345d64",
-    remote = "https://github.com/bazelbuild/rules_rust.git",
+    commit = "732695b6",
+    remote = "https://github.com/avrabe/rules_rust.git",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.8.2")


### PR DESCRIPTION
## Summary
Combines two fixes for the persistent Windows LNK1181 error:

1. **LIBPATH quoting** (MODULE.bazel): Point at `avrabe/rules_rust` `fix/windows-libpath-quoting` branch which quotes paths with spaces in `bootstrap_process_wrapper.bat`
2. **Short output_base** (ci.yml): Use `--output_base=D:\_b` to avoid Windows MAX_PATH (260 char) limit — the rlib paths are ~250 chars with the default output_base

## Test plan
- [x] Builds pass locally (macOS)
- [ ] **Key test**: `Test on windows-latest` passes with both fixes combined
- [ ] All other CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)