### PR TITLE
feat: PulseEngine pipeline rules + P3 toolchain bump

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -157,7 +157,7 @@ wkg = use_extension("//wasm:extensions.bzl", "wkg")
 wkg.register(
     name = "wkg",
     strategy = "download",
-    version = "0.13.0",
+    version = "0.15.0",
 )
 use_repo(wkg, "wkg_toolchain")
 
@@ -197,7 +197,7 @@ wasmtime = use_extension("//wasm:extensions.bzl", "wasmtime")
 wasmtime.register(
     name = "wasmtime",
     strategy = "download",
-    version = "39.0.1",
+    version = "43.0.1",
 )
 use_repo(wasmtime, "wasmtime_toolchain")
 
@@ -219,14 +219,14 @@ bazel_dep(name = "rules_nodejs", version = "6.5.0")
 
 # Configure Node.js version and tools
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
-node.toolchain(node_version = "24.14.0")
+node.toolchain(node_version = "24.14.1")
 use_repo(node, "nodejs_toolchains")
 
 # JavaScript/TypeScript WebAssembly components with JCO
 jco = use_extension("//wasm:extensions.bzl", "jco")
 jco.register(
     name = "jco",
-    node_version = "24.14.0",
+    node_version = "24.14.1",
     version = "1.4.0",
 )
 use_repo(jco, "jco_toolchain")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -294,7 +294,7 @@ wasm_component_download(
     name = "wasmsign2_cli_wasm",
     filename = "wasmsign2.wasm",
     tool_name = "wsc",
-    version = "0.4.0",
+    version = "0.7.0",
 )
 
 # LOOM WebAssembly optimizer (version in //checksums/tools/loom.json)
@@ -302,7 +302,7 @@ wasm_component_download(
     name = "loom_wasm",
     filename = "loom.wasm",
     tool_name = "loom",
-    version = "0.1.0-rc1",
+    version = "0.3.0",
 )
 
 # WASM Tools Component toolchain for universal wasm-tools operations

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -219,14 +219,14 @@ bazel_dep(name = "rules_nodejs", version = "6.5.0")
 
 # Configure Node.js version and tools
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
-node.toolchain(node_version = "24.14.1")
+node.toolchain(node_version = "24.14.0")
 use_repo(node, "nodejs_toolchains")
 
 # JavaScript/TypeScript WebAssembly components with JCO
 jco = use_extension("//wasm:extensions.bzl", "jco")
 jco.register(
     name = "jco",
-    node_version = "24.14.1",
+    node_version = "24.14.0",
     version = "1.4.0",
 )
 use_repo(jco, "jco_toolchain")
@@ -251,7 +251,7 @@ register_toolchains("@jco_toolchain//:jco_toolchain")
 binaryen = use_extension("//wasm:extensions.bzl", "binaryen")
 binaryen.register(
     name = "binaryen",
-    version = "123",
+    version = "129",
 )
 use_repo(binaryen, "binaryen_toolchain")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -16,9 +16,9 @@
     "https://bcr.bazel.build/modules/apple_support/1.24.1/source.json": "cf725267cbacc5f028ef13bb77e7f2c2e0066923a4dab1025e4a0511b1ed258a",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.3/MODULE.bazel": "253d739ba126f62a5767d832765b12b59e9f8d2bc88cc1572f4a73e46eb298ca",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.21.1/MODULE.bazel": "07e3ce3eaaa50dbd0be7fa0094e36890478937adc780ec53e77fd9fe543af8b1",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.5/MODULE.bazel": "004ba890363d05372a97248c37205ae64b6fa31047629cd2c0895a9d0c7779e8",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.5/source.json": "ac2c3213df8f985785f1d0aeb7f0f73d5324e6e67d593d9b9470fb74a25d4a9b",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.7.2/MODULE.bazel": "780d1a6522b28f5edb7ea09630748720721dfe27690d65a2d33aa7509de77e07",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/MODULE.bazel": "812d2dd42f65dca362152101fbec418029cc8fd34cbad1a2fde905383d705838",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
@@ -34,7 +34,9 @@
     "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
     "https://bcr.bazel.build/modules/bazel_features/1.32.0/MODULE.bazel": "095d67022a58cb20f7e20e1aefecfa65257a222c18a938e2914fd257b5f1ccdc",
     "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
-    "https://bcr.bazel.build/modules/bazel_features/1.33.0/source.json": "13617db3930328c2cd2807a0f13d52ca870ac05f96db9668655113265147b2a6",
+    "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
+    "https://bcr.bazel.build/modules/bazel_features/1.36.0/MODULE.bazel": "596cb62090b039caf1cad1d52a8bc35cf188ca9a4e279a828005e7ee49a1bec3",
+    "https://bcr.bazel.build/modules/bazel_features/1.36.0/source.json": "279625cafa5b63cc0a8ee8448d93bc5ac1431f6000c50414051173fd22a6df3c",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
@@ -52,9 +54,10 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/source.json": "34a3c8bcf233b835eb74be9d628899bb32999d3e0eadef1947a0a562a2b16ffb",
-    "https://bcr.bazel.build/modules/buildifier_prebuilt/6.4.0/MODULE.bazel": "37389c6b5a40c59410b4226d3bb54b08637f393d66e2fa57925c6fcf68e64bf4",
-    "https://bcr.bazel.build/modules/buildifier_prebuilt/6.4.0/source.json": "83eb01b197ed0b392f797860c9da5ed1bf95f4d0ded994d694a3d44731275916",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/MODULE.bazel": "72997b29dfd95c3fa0d0c48322d05590418edef451f8db8db5509c57875fb4b7",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/source.json": "7ad77c1e8c1b84222d9b3f3cae016a76639435744c19330b0b37c0a3c9da7dc0",
+    "https://bcr.bazel.build/modules/buildifier_prebuilt/8.5.1/MODULE.bazel": "77f2a1958d1d07376dd3ce3ae16540f2c1b01921c1fd21930827271260e75a66",
+    "https://bcr.bazel.build/modules/buildifier_prebuilt/8.5.1/source.json": "ae9f3d9dc7bec033976cf47165a78788bebad2b5c272241063ae31bad8664fd4",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/fmt/10.1.1/MODULE.bazel": "577a09aa892764bbe13cd0fb2bcdbace97416d9aa8ca625c5ca6f6f3f22a2b1d",
@@ -82,7 +85,8 @@
     "https://bcr.bazel.build/modules/nlohmann_json/3.11.3/source.json": "296c63a90c6813e53b3812d24245711981fc7e563d98fe15625f55181494488a",
     "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
     "https://bcr.bazel.build/modules/package_metadata/0.0.2/MODULE.bazel": "fb8d25550742674d63d7b250063d4580ca530499f045d70748b1b142081ebb92",
-    "https://bcr.bazel.build/modules/package_metadata/0.0.2/source.json": "e53a759a72488d2c0576f57491ef2da0cf4aab05ac0997314012495935531b73",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.6/MODULE.bazel": "341dab6f417197494517d54c8e557c0baee1de7aec83543a4fbefe57900acb7e",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.6/source.json": "9581d8b22db43550ac75ecc314ee4fa0a33400bfdc77d1317d8af6b18dca7756",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
@@ -119,18 +123,17 @@
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
     "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.14/MODULE.bazel": "353c99ed148887ee89c54a17d4100ae7e7e436593d104b668476019023b58df8",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.14/source.json": "55d0a4587c5592fad350f6e698530f4faf0e7dd15e69d43f8d87e220c78bea54",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.17/source.json": "3832f45d145354049137c0090df04629d9c2b5493dc5c2bf46f1834040133a07",
     "https://bcr.bazel.build/modules/rules_cc/0.2.4/MODULE.bazel": "1ff1223dfd24f3ecf8f028446d4a27608aa43c3f41e346d22838a4223980b8cc",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
     "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
     "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
-    "https://bcr.bazel.build/modules/rules_go/0.59.0/MODULE.bazel": "b7e43e7414a3139a7547d1b4909b29085fbe5182b6c58cbe1ed4c6272815aeae",
-    "https://bcr.bazel.build/modules/rules_go/0.59.0/source.json": "1df17bb7865cfc029492c30163cee891d0dd8658ea0d5bfdf252c4b6db5c1ef6",
+    "https://bcr.bazel.build/modules/rules_go/0.60.0/MODULE.bazel": "4a57ff2ffc2a3570e3c5646575c5a4b07287e91bcdac5d1f72383d51502b48cb",
+    "https://bcr.bazel.build/modules/rules_go/0.60.0/source.json": "1e21368c5e0c3013a110bd79a8fcff8ca46b5bcb2b561713a7273cbfcff7c464",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
-    "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
     "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
     "https://bcr.bazel.build/modules/rules_java/6.3.0/MODULE.bazel": "a97c7678c19f236a956ad260d59c86e10a463badb7eb2eda787490f4c969b963",
     "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
@@ -147,6 +150,7 @@
     "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.6/MODULE.bazel": "153042249c7060536dc95b6bb9f9bb8063b8a0b0cb7acdb381bddbc2374aed55",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.7/MODULE.bazel": "e717beabc4d091ecb2c803c2d341b88590e9116b8bf7947915eeb33aab4f96dd",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.7/source.json": "5426f412d0a7fc6b611643376c7e4a82dec991491b9ce5cb1cfdd25fe2e92be4",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
@@ -158,8 +162,8 @@
     "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
     "https://bcr.bazel.build/modules/rules_nodejs/6.5.0/MODULE.bazel": "546d0cf79f36f9f6e080816045f97234b071c205f4542e3351bd4424282a8810",
     "https://bcr.bazel.build/modules/rules_nodejs/6.5.0/source.json": "ac075bc5babebc25a0adc88ee885f2c8d8520d141f6e139ba9dfa0eedb5be908",
-    "https://bcr.bazel.build/modules/rules_oci/2.2.6/MODULE.bazel": "2ba6ddd679269e00aeffe9ca04faa2d0ca4129650982c9246d0d459fe2da47d9",
-    "https://bcr.bazel.build/modules/rules_oci/2.2.6/source.json": "94e7decb8f95d9465b0bbea71c65064cd16083be1350c7468f131818641dc4a5",
+    "https://bcr.bazel.build/modules/rules_oci/2.3.0/MODULE.bazel": "49075197960c924c0a4d759b7c765c3d00a41d2fdd4a943b42823c1d016ab4ec",
+    "https://bcr.bazel.build/modules/rules_oci/2.3.0/source.json": "47710c28446211b5e61a24015a4669c50c6862d5f91e6bdbc710de8d750cf613",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
@@ -189,18 +193,19 @@
     "https://bcr.bazel.build/modules/spdlog/1.12.0/MODULE.bazel": "b3cad7caea1d4199029d33bcfaea1e9da17f3bf84f888392e6ba9fa1da805499",
     "https://bcr.bazel.build/modules/spdlog/1.12.0/source.json": "f63f6e082ea7ef82ca256a8ca54e98808fbb486f1fa6140bcaa618fb63d45a7e",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
-    "https://bcr.bazel.build/modules/stardoc/0.5.4/MODULE.bazel": "6569966df04610b8520957cb8e97cf2e9faac2c0309657c537ab51c16c18a2a4",
     "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
     "https://bcr.bazel.build/modules/stardoc/0.6.2/MODULE.bazel": "7060193196395f5dd668eda046ccbeacebfd98efc77fed418dbe2b82ffaa39fd",
     "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
     "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
-    "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
+    "https://bcr.bazel.build/modules/stardoc/0.8.1/MODULE.bazel": "176fef488dce8e5943c8fac37eade418b80b3846fdfd69f0457165375b6b0e68",
+    "https://bcr.bazel.build/modules/stardoc/0.8.1/source.json": "96482be3dc73e845e2dabb94103121d57a0f3f49663aa4cc4150b44c68fb4a55",
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/source.json": "32bd87e5f4d7acc57c5b2ff7c325ae3061d5e242c0c4c214ae87e0f1c13e54cb",
     "https://bcr.bazel.build/modules/tar.bzl/0.2.1/MODULE.bazel": "52d1c00a80a8cc67acbd01649e83d8dd6a9dc426a6c0b754a04fe8c219c76468",
     "https://bcr.bazel.build/modules/tar.bzl/0.5.1/MODULE.bazel": "7c2eb3dcfc53b0f3d6f9acdfd911ca803eaf92aadf54f8ca6e4c1f3aee288351",
-    "https://bcr.bazel.build/modules/tar.bzl/0.5.1/source.json": "deed3094f7cc779ed1d37a68403847b0e38d9dd9d931e03cb90825f3368b515f",
+    "https://bcr.bazel.build/modules/tar.bzl/0.7.0/MODULE.bazel": "cc1acd85da33c80e430b65219a620d54d114628df24a618c3a5fa0b65e988da9",
+    "https://bcr.bazel.build/modules/tar.bzl/0.7.0/source.json": "9becb80306f42d4810bfa16379fb48aad0b01ce5342bc12fe47dcd6af3ac4d7a",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/source.json": "2d2bad780a9f2b9195a4a370314d2c17ae95eaa745cefc2e12fbc49759b15aa3",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
@@ -277,7 +282,7 @@
     },
     "//wasm:extensions.bzl%binaryen": {
       "general": {
-        "bzlTransitiveDigest": "SVKhFVQvwMQqhCTqTVXhpJjKp14p4hJekEuPLftJpWY=",
+        "bzlTransitiveDigest": "vwAB/rcHQQsX8wFdQ6icGnBxU95AKGmZvVQ9NFVQ8dc=",
         "usagesDigest": "5pa+PwHAq0okHMi9pI+B9veNJJ8THWxT23apDX4U/4c=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -299,33 +304,9 @@
         ]
       }
     },
-    "//wasm:extensions.bzl%componentize_py": {
-      "general": {
-        "bzlTransitiveDigest": "SVKhFVQvwMQqhCTqTVXhpJjKp14p4hJekEuPLftJpWY=",
-        "usagesDigest": "Rn73zLiFCwY95fZY+ZqrPNxs6/LMJw64sPJB6gIC/J8=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "componentize_py_toolchain": {
-            "repoRuleId": "@@//toolchains:componentize_py_toolchain.bzl%componentize_py_toolchain_repository",
-            "attributes": {
-              "version": "canary"
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    },
     "//wasm:extensions.bzl%cpp_component": {
       "general": {
-        "bzlTransitiveDigest": "SVKhFVQvwMQqhCTqTVXhpJjKp14p4hJekEuPLftJpWY=",
+        "bzlTransitiveDigest": "vwAB/rcHQQsX8wFdQ6icGnBxU95AKGmZvVQ9NFVQ8dc=",
         "usagesDigest": "6UgLH0voNNqp5nvGAZIPdkqBNHnYJns3D47wtyD/QX4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -350,8 +331,8 @@
     },
     "//wasm:extensions.bzl%jco": {
       "general": {
-        "bzlTransitiveDigest": "SVKhFVQvwMQqhCTqTVXhpJjKp14p4hJekEuPLftJpWY=",
-        "usagesDigest": "Q/dCQKDfQQu8p/6sB8y5vGvN4aSwDm+u8BTrw309aao=",
+        "bzlTransitiveDigest": "vwAB/rcHQQsX8wFdQ6icGnBxU95AKGmZvVQ9NFVQ8dc=",
+        "usagesDigest": "EBF1KBwpfJ1aAg4N+iBxBkHr3C8kU856a5qUoN79d0s=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -360,7 +341,7 @@
             "repoRuleId": "@@//toolchains:jco_toolchain.bzl%jco_toolchain_repository",
             "attributes": {
               "version": "1.4.0",
-              "node_version": "20.18.0"
+              "node_version": "24.14.0"
             }
           }
         },
@@ -375,7 +356,7 @@
     },
     "//wasm:extensions.bzl%tinygo": {
       "general": {
-        "bzlTransitiveDigest": "SVKhFVQvwMQqhCTqTVXhpJjKp14p4hJekEuPLftJpWY=",
+        "bzlTransitiveDigest": "vwAB/rcHQQsX8wFdQ6icGnBxU95AKGmZvVQ9NFVQ8dc=",
         "usagesDigest": "esnFdrH+qxI9awhZ/uW4dIkm843wWmTCzO4b1pdmifs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -399,7 +380,7 @@
     },
     "//wasm:extensions.bzl%wasi_sdk": {
       "general": {
-        "bzlTransitiveDigest": "SVKhFVQvwMQqhCTqTVXhpJjKp14p4hJekEuPLftJpWY=",
+        "bzlTransitiveDigest": "vwAB/rcHQQsX8wFdQ6icGnBxU95AKGmZvVQ9NFVQ8dc=",
         "usagesDigest": "juzRCJg8/dKfNzkycrcpYBYuXmaqqX3TTt8KL2C78kQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -773,7 +754,7 @@
     },
     "//wasm:extensions.bzl%wasm_toolchain": {
       "general": {
-        "bzlTransitiveDigest": "SVKhFVQvwMQqhCTqTVXhpJjKp14p4hJekEuPLftJpWY=",
+        "bzlTransitiveDigest": "vwAB/rcHQQsX8wFdQ6icGnBxU95AKGmZvVQ9NFVQ8dc=",
         "usagesDigest": "XNTBNCoyj6s3okyF8agUT6PMhSUgcjtD7Xu3qTDS5gk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -807,7 +788,7 @@
     },
     "//wasm:extensions.bzl%wasmtime": {
       "general": {
-        "bzlTransitiveDigest": "SVKhFVQvwMQqhCTqTVXhpJjKp14p4hJekEuPLftJpWY=",
+        "bzlTransitiveDigest": "vwAB/rcHQQsX8wFdQ6icGnBxU95AKGmZvVQ9NFVQ8dc=",
         "usagesDigest": "PpxDa2eMax8/BzkpUSZ6gcDqno6zdEEEIv2sK4Mt7IM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -832,7 +813,7 @@
     },
     "//wasm:extensions.bzl%wkg": {
       "general": {
-        "bzlTransitiveDigest": "SVKhFVQvwMQqhCTqTVXhpJjKp14p4hJekEuPLftJpWY=",
+        "bzlTransitiveDigest": "vwAB/rcHQQsX8wFdQ6icGnBxU95AKGmZvVQ9NFVQ8dc=",
         "usagesDigest": "LD17gw0uxOCd7fuDnQS0uUArJBOS3hJSAa6FPd3tZS8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -852,145 +833,6 @@
         "recordedRepoMappingEntries": [
           [
             "",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    },
-    "@@buildifier_prebuilt+//:defs.bzl%buildifier_prebuilt_deps_extension": {
-      "general": {
-        "bzlTransitiveDigest": "77wpjIiy5v7dmpUSToH3MqQClBXIkE2DrGCwATf08g4=",
-        "usagesDigest": "m+RORtK3MOrJs2auGj/7mY7N11R7swVsHYHg1jls5hs=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "buildifier_darwin_amd64": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
-            "attributes": {
-              "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildifier-darwin-amd64"
-              ],
-              "downloaded_file_path": "buildifier",
-              "executable": true,
-              "sha256": "eeb47b2de27f60efe549348b183fac24eae80f1479e8b06cac0799c486df5bed"
-            }
-          },
-          "buildifier_darwin_arm64": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
-            "attributes": {
-              "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildifier-darwin-arm64"
-              ],
-              "downloaded_file_path": "buildifier",
-              "executable": true,
-              "sha256": "fa07ba0d20165917ca4cc7609f9b19a8a4392898148b7babdf6bb2a7dd963f05"
-            }
-          },
-          "buildifier_linux_amd64": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
-            "attributes": {
-              "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildifier-linux-amd64"
-              ],
-              "downloaded_file_path": "buildifier",
-              "executable": true,
-              "sha256": "be63db12899f48600bad94051123b1fd7b5251e7661b9168582ce52396132e92"
-            }
-          },
-          "buildifier_linux_arm64": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
-            "attributes": {
-              "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildifier-linux-arm64"
-              ],
-              "downloaded_file_path": "buildifier",
-              "executable": true,
-              "sha256": "18540fc10f86190f87485eb86963e603e41fa022f88a2d1b0cf52ff252b5e1dd"
-            }
-          },
-          "buildifier_windows_amd64": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
-            "attributes": {
-              "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildifier-windows-amd64.exe"
-              ],
-              "downloaded_file_path": "buildifier.exe",
-              "executable": true,
-              "sha256": "da8372f35e34b65fb6d997844d041013bb841e55f58b54d596d35e49680fe13c"
-            }
-          },
-          "buildozer_darwin_amd64": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
-            "attributes": {
-              "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildozer-darwin-amd64"
-              ],
-              "downloaded_file_path": "buildozer",
-              "executable": true,
-              "sha256": "d29e347ecd6b5673d72cb1a8de05bf1b06178dd229ff5eb67fad5100c840cc8e"
-            }
-          },
-          "buildozer_darwin_arm64": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
-            "attributes": {
-              "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildozer-darwin-arm64"
-              ],
-              "downloaded_file_path": "buildozer",
-              "executable": true,
-              "sha256": "9b9e71bdbec5e7223871e913b65d12f6d8fa026684daf991f00e52ed36a6978d"
-            }
-          },
-          "buildozer_linux_amd64": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
-            "attributes": {
-              "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildozer-linux-amd64"
-              ],
-              "downloaded_file_path": "buildozer",
-              "executable": true,
-              "sha256": "8dfd6345da4e9042daa738d7fdf34f699c5dfce4632f7207956fceedd8494119"
-            }
-          },
-          "buildozer_linux_arm64": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
-            "attributes": {
-              "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildozer-linux-arm64"
-              ],
-              "downloaded_file_path": "buildozer",
-              "executable": true,
-              "sha256": "6559558fded658c8fa7432a9d011f7c4dcbac6b738feae73d2d5c352e5f605fa"
-            }
-          },
-          "buildozer_windows_amd64": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
-            "attributes": {
-              "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildozer-windows-amd64.exe"
-              ],
-              "downloaded_file_path": "buildozer.exe",
-              "executable": true,
-              "sha256": "e7f05bf847f7c3689dd28926460ce6e1097ae97380ac8e6ae7147b7b706ba19b"
-            }
-          },
-          "buildifier_prebuilt_toolchains": {
-            "repoRuleId": "@@buildifier_prebuilt+//:defs.bzl%_buildifier_toolchain_setup",
-            "attributes": {
-              "assets_json": "[{\"arch\":\"amd64\",\"name\":\"buildifier\",\"platform\":\"darwin\",\"sha256\":\"eeb47b2de27f60efe549348b183fac24eae80f1479e8b06cac0799c486df5bed\",\"version\":\"v6.4.0\"},{\"arch\":\"arm64\",\"name\":\"buildifier\",\"platform\":\"darwin\",\"sha256\":\"fa07ba0d20165917ca4cc7609f9b19a8a4392898148b7babdf6bb2a7dd963f05\",\"version\":\"v6.4.0\"},{\"arch\":\"amd64\",\"name\":\"buildifier\",\"platform\":\"linux\",\"sha256\":\"be63db12899f48600bad94051123b1fd7b5251e7661b9168582ce52396132e92\",\"version\":\"v6.4.0\"},{\"arch\":\"arm64\",\"name\":\"buildifier\",\"platform\":\"linux\",\"sha256\":\"18540fc10f86190f87485eb86963e603e41fa022f88a2d1b0cf52ff252b5e1dd\",\"version\":\"v6.4.0\"},{\"arch\":\"amd64\",\"name\":\"buildifier\",\"platform\":\"windows\",\"sha256\":\"da8372f35e34b65fb6d997844d041013bb841e55f58b54d596d35e49680fe13c\",\"version\":\"v6.4.0\"},{\"arch\":\"amd64\",\"name\":\"buildozer\",\"platform\":\"darwin\",\"sha256\":\"d29e347ecd6b5673d72cb1a8de05bf1b06178dd229ff5eb67fad5100c840cc8e\",\"version\":\"v6.4.0\"},{\"arch\":\"arm64\",\"name\":\"buildozer\",\"platform\":\"darwin\",\"sha256\":\"9b9e71bdbec5e7223871e913b65d12f6d8fa026684daf991f00e52ed36a6978d\",\"version\":\"v6.4.0\"},{\"arch\":\"amd64\",\"name\":\"buildozer\",\"platform\":\"linux\",\"sha256\":\"8dfd6345da4e9042daa738d7fdf34f699c5dfce4632f7207956fceedd8494119\",\"version\":\"v6.4.0\"},{\"arch\":\"arm64\",\"name\":\"buildozer\",\"platform\":\"linux\",\"sha256\":\"6559558fded658c8fa7432a9d011f7c4dcbac6b738feae73d2d5c352e5f605fa\",\"version\":\"v6.4.0\"},{\"arch\":\"amd64\",\"name\":\"buildozer\",\"platform\":\"windows\",\"sha256\":\"e7f05bf847f7c3689dd28926460ce6e1097ae97380ac8e6ae7147b7b706ba19b\",\"version\":\"v6.4.0\"}]"
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "buildifier_prebuilt+",
-            "bazel_skylib",
-            "bazel_skylib+"
-          ],
-          [
-            "buildifier_prebuilt+",
             "bazel_tools",
             "bazel_tools"
           ]
@@ -1061,34 +903,10 @@
         ]
       }
     },
-    "@@rules_moonbit+//moonbit:extensions.bzl%moonbit_toolchain_extension": {
-      "general": {
-        "bzlTransitiveDigest": "oDnkJPBoCGNevuTitYsLgEWWBBb0rK9sPl5M8CU3goM=",
-        "usagesDigest": "fF6KU+z/6N3W8PsyD6gfOMAXr3JDQymYQ9OLrVh9FFI=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "moonbit_toolchain": {
-            "repoRuleId": "@@rules_moonbit+//moonbit/tools:hermetic_toolchain.bzl%moonbit_toolchain_repository",
-            "attributes": {
-              "version": ""
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_moonbit+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    },
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "hdICB1K7PX7oWtO8oksVTBDNt6xxiNERpcO4Yxoa0Gc=",
-        "usagesDigest": "sI0T/YWgioVal40qHxpqaq+cfjOVW2g/c83ZoS57kBo=",
+        "usagesDigest": "wBT3TSMzf82waeXIT0i/80Ot0kq4jHEoG3IidXPV3As=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1101,7 +919,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.18.0",
+              "node_version": "24.14.0",
               "include_headers": false,
               "platform": "linux_amd64"
             }
@@ -1114,7 +932,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.18.0",
+              "node_version": "24.14.0",
               "include_headers": false,
               "platform": "linux_arm64"
             }
@@ -1127,7 +945,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.18.0",
+              "node_version": "24.14.0",
               "include_headers": false,
               "platform": "linux_s390x"
             }
@@ -1140,7 +958,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.18.0",
+              "node_version": "24.14.0",
               "include_headers": false,
               "platform": "linux_ppc64le"
             }
@@ -1153,7 +971,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.18.0",
+              "node_version": "24.14.0",
               "include_headers": false,
               "platform": "darwin_amd64"
             }
@@ -1166,7 +984,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.18.0",
+              "node_version": "24.14.0",
               "include_headers": false,
               "platform": "darwin_arm64"
             }
@@ -1179,7 +997,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.18.0",
+              "node_version": "24.14.0",
               "include_headers": false,
               "platform": "windows_amd64"
             }
@@ -1192,7 +1010,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.18.0",
+              "node_version": "24.14.0",
               "include_headers": false,
               "platform": "windows_arm64"
             }
@@ -1217,163 +1035,6 @@
           }
         },
         "recordedRepoMappingEntries": []
-      }
-    },
-    "@@rules_oci+//oci:extensions.bzl%oci": {
-      "general": {
-        "bzlTransitiveDigest": "azn4rR/FOgFIZK9m3hVUsQo1NmPDGQxwoqfUbHPYJvw=",
-        "usagesDigest": "/O1PwnnkqSBmI9Oe08ZYYqjM4IS8JR+/9rjgzVTNDaQ=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "oci_crane_darwin_amd64": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%crane_repositories",
-            "attributes": {
-              "platform": "darwin_amd64",
-              "crane_version": "v0.18.0"
-            }
-          },
-          "oci_crane_darwin_arm64": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%crane_repositories",
-            "attributes": {
-              "platform": "darwin_arm64",
-              "crane_version": "v0.18.0"
-            }
-          },
-          "oci_crane_linux_arm64": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%crane_repositories",
-            "attributes": {
-              "platform": "linux_arm64",
-              "crane_version": "v0.18.0"
-            }
-          },
-          "oci_crane_linux_armv6": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%crane_repositories",
-            "attributes": {
-              "platform": "linux_armv6",
-              "crane_version": "v0.18.0"
-            }
-          },
-          "oci_crane_linux_i386": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%crane_repositories",
-            "attributes": {
-              "platform": "linux_i386",
-              "crane_version": "v0.18.0"
-            }
-          },
-          "oci_crane_linux_s390x": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%crane_repositories",
-            "attributes": {
-              "platform": "linux_s390x",
-              "crane_version": "v0.18.0"
-            }
-          },
-          "oci_crane_linux_amd64": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%crane_repositories",
-            "attributes": {
-              "platform": "linux_amd64",
-              "crane_version": "v0.18.0"
-            }
-          },
-          "oci_crane_windows_armv6": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%crane_repositories",
-            "attributes": {
-              "platform": "windows_armv6",
-              "crane_version": "v0.18.0"
-            }
-          },
-          "oci_crane_windows_amd64": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%crane_repositories",
-            "attributes": {
-              "platform": "windows_amd64",
-              "crane_version": "v0.18.0"
-            }
-          },
-          "oci_crane_toolchains": {
-            "repoRuleId": "@@rules_oci+//oci/private:toolchains_repo.bzl%toolchains_repo",
-            "attributes": {
-              "toolchain_type": "@rules_oci//oci:crane_toolchain_type",
-              "toolchain": "@oci_crane_{platform}//:crane_toolchain"
-            }
-          },
-          "oci_regctl_darwin_amd64": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%regctl_repositories",
-            "attributes": {
-              "platform": "darwin_amd64"
-            }
-          },
-          "oci_regctl_darwin_arm64": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%regctl_repositories",
-            "attributes": {
-              "platform": "darwin_arm64"
-            }
-          },
-          "oci_regctl_linux_arm64": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%regctl_repositories",
-            "attributes": {
-              "platform": "linux_arm64"
-            }
-          },
-          "oci_regctl_linux_s390x": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%regctl_repositories",
-            "attributes": {
-              "platform": "linux_s390x"
-            }
-          },
-          "oci_regctl_linux_amd64": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%regctl_repositories",
-            "attributes": {
-              "platform": "linux_amd64"
-            }
-          },
-          "oci_regctl_windows_amd64": {
-            "repoRuleId": "@@rules_oci+//oci:repositories.bzl%regctl_repositories",
-            "attributes": {
-              "platform": "windows_amd64"
-            }
-          },
-          "oci_regctl_toolchains": {
-            "repoRuleId": "@@rules_oci+//oci/private:toolchains_repo.bzl%toolchains_repo",
-            "attributes": {
-              "toolchain_type": "@rules_oci//oci:regctl_toolchain_type",
-              "toolchain": "@oci_regctl_{platform}//:regctl_toolchain"
-            }
-          }
-        },
-        "moduleExtensionMetadata": {
-          "explicitRootModuleDirectDeps": [],
-          "explicitRootModuleDirectDevDeps": [],
-          "useAllRepos": "NO",
-          "reproducible": false
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "aspect_bazel_lib+",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "bazel_features+",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "rules_oci+",
-            "aspect_bazel_lib",
-            "aspect_bazel_lib+"
-          ],
-          [
-            "rules_oci+",
-            "bazel_features",
-            "bazel_features+"
-          ],
-          [
-            "rules_oci+",
-            "bazel_skylib",
-            "bazel_skylib+"
-          ]
-        ]
       }
     },
     "@@rules_python+//python/uv:uv.bzl%uv": {
@@ -11039,60 +10700,6 @@
             "rules_rust+"
           ]
         ]
-      }
-    },
-    "@@tar.bzl+//tar:extensions.bzl%toolchains": {
-      "general": {
-        "bzlTransitiveDigest": "/2afh6fPjq/rcyE/jztQDK3ierehmFFngfvmqyRv72M=",
-        "usagesDigest": "maF8qsAIqeH1ey8pxP0gNZbvJt34kLZvTFeQ0ntrJVA=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "bsd_tar_toolchains": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:toolchain.bzl%tar_toolchains_repo",
-            "attributes": {
-              "user_repository_name": "bsd_tar_toolchains"
-            }
-          },
-          "bsd_tar_toolchains_darwin_amd64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "darwin_amd64"
-            }
-          },
-          "bsd_tar_toolchains_darwin_arm64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "darwin_arm64"
-            }
-          },
-          "bsd_tar_toolchains_linux_amd64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "linux_amd64"
-            }
-          },
-          "bsd_tar_toolchains_linux_arm64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "linux_arm64"
-            }
-          },
-          "bsd_tar_toolchains_windows_amd64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "windows_amd64"
-            }
-          },
-          "bsd_tar_toolchains_windows_arm64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "windows_arm64"
-            }
-          }
-        },
-        "recordedRepoMappingEntries": []
       }
     }
   }

--- a/checksums/registry.bzl
+++ b/checksums/registry.bzl
@@ -174,6 +174,7 @@ def list_available_tools():
         "binaryen",
         "tinygo",
         "loom",
+        "meld",
         "wsc",
     ]
 

--- a/checksums/tools/binaryen.json
+++ b/checksums/tools/binaryen.json
@@ -29,6 +29,31 @@
         }
       }
     },
+    "123": {
+      "release_date": "2025-03-27",
+      "platforms": {
+        "darwin_arm64": {
+          "sha256": "74428be348c1a09863e7b642a1fa948cabf8ec9561052233d8288e941951725b",
+          "url_suffix": "arm64-macos.tar.gz"
+        },
+        "darwin_amd64": {
+          "sha256": "cc18b14d2b673d9c66bf54f31ff2b0ceb23ba5132455b893965ae2792f9e00dd",
+          "url_suffix": "x86_64-macos.tar.gz"
+        },
+        "linux_amd64": {
+          "sha256": "e959f2170af4c20c552e9de3a0253704d6a9d2766e8fdb88e4d6ac4bae9388fe",
+          "url_suffix": "x86_64-linux.tar.gz"
+        },
+        "linux_arm64": {
+          "sha256": "4b6bd61ba6cd3b18c993b4657d93426c782f9b91b74be0d38018cd8be1319376",
+          "url_suffix": "aarch64-linux.tar.gz"
+        },
+        "windows_amd64": {
+          "sha256": "7b3568424a0f871a52865d5c78177db646b1832a8c487321e27703103f936880",
+          "url_suffix": "x86_64-windows.tar.gz"
+        }
+      }
+    },
     "128": {
       "release_date": "2026-03-13",
       "platforms": {

--- a/checksums/tools/binaryen.json
+++ b/checksums/tools/binaryen.json
@@ -1,19 +1,44 @@
 {
   "tool_name": "binaryen",
   "github_repo": "WebAssembly/binaryen",
-  "latest_version": "128",
-  "last_checked": "2026-03-15T00:00:00Z",
+  "latest_version": "129",
+  "last_checked": "2026-04-13T00:00:00Z",
   "versions": {
+    "129": {
+      "release_date": "2026-04-01",
+      "platforms": {
+        "darwin_arm64": {
+          "sha256": "d1bb014775ca3002506712b81b4406d126ff6845e8b2f343bc2696a1a88b7117",
+          "url_suffix": "arm64-macos.tar.gz"
+        },
+        "darwin_amd64": {
+          "sha256": "cc38897d3d93c968f24819fae210e04afd0146d0e2467e307207ea7e798a59b9",
+          "url_suffix": "x86_64-macos.tar.gz"
+        },
+        "linux_amd64": {
+          "sha256": "50b9fa62b9abea752da92ec57e0c555fee578760cd237c40107957715d2976ba",
+          "url_suffix": "x86_64-linux.tar.gz"
+        },
+        "linux_arm64": {
+          "sha256": "81d46b86b10876ab615eec67e09fcc5615115a7b189cfe3d466725ee36c46ac2",
+          "url_suffix": "aarch64-linux.tar.gz"
+        },
+        "windows_amd64": {
+          "sha256": "1405d2f51377859ccf5fcd2c59c0a8c5756373e691ca0eeb5219f646b743e3aa",
+          "url_suffix": "x86_64-windows.tar.gz"
+        }
+      }
+    },
     "128": {
       "release_date": "2026-03-13",
       "platforms": {
-        "darwin_amd64": {
-          "sha256": "0b4bbd58c46b73a3de1fd485579a56cd413dd395414306d9f33df407fde58b9b",
-          "url_suffix": "x86_64-macos.tar.gz"
-        },
         "darwin_arm64": {
           "sha256": "0ef730ecedf2dac894812185fc78f5940ab980cdde79427e49fa87331d24422f",
           "url_suffix": "arm64-macos.tar.gz"
+        },
+        "darwin_amd64": {
+          "sha256": "0b4bbd58c46b73a3de1fd485579a56cd413dd395414306d9f33df407fde58b9b",
+          "url_suffix": "x86_64-macos.tar.gz"
         },
         "linux_amd64": {
           "sha256": "4ce79586d1c4762502eebe9a1db071fa5e446ef8897f2f766eb1cce5ec6dee9e",
@@ -25,31 +50,6 @@
         },
         "windows_amd64": {
           "sha256": "3726e4ac3c957ffa6bcf5daf34f2bec877d7cefe7474265a819f0c8a3f8b158e",
-          "url_suffix": "x86_64-windows.tar.gz"
-        }
-      }
-    },
-    "123": {
-      "release_date": "2025-03-27",
-      "platforms": {
-        "darwin_amd64": {
-          "sha256": "cc18b14d2b673d9c66bf54f31ff2b0ceb23ba5132455b893965ae2792f9e00dd",
-          "url_suffix": "x86_64-macos.tar.gz"
-        },
-        "darwin_arm64": {
-          "sha256": "74428be348c1a09863e7b642a1fa948cabf8ec9561052233d8288e941951725b",
-          "url_suffix": "arm64-macos.tar.gz"
-        },
-        "linux_amd64": {
-          "sha256": "e959f2170af4c20c552e9de3a0253704d6a9d2766e8fdb88e4d6ac4bae9388fe",
-          "url_suffix": "x86_64-linux.tar.gz"
-        },
-        "linux_arm64": {
-          "sha256": "4b6bd61ba6cd3b18c993b4657d93426c782f9b91b74be0d38018cd8be1319376",
-          "url_suffix": "aarch64-linux.tar.gz"
-        },
-        "windows_amd64": {
-          "sha256": "7b3568424a0f871a52865d5c78177db646b1832a8c487321e27703103f936880",
           "url_suffix": "x86_64-windows.tar.gz"
         }
       }

--- a/checksums/tools/loom.json
+++ b/checksums/tools/loom.json
@@ -2,31 +2,30 @@
   "tool_name": "loom",
   "github_repo": "pulseengine/loom",
   "description": "WebAssembly optimizer with formal verification support",
-  "latest_version": "0.1.0-rc1",
+  "latest_version": "0.3.0",
   "supported_platforms": ["darwin_amd64", "darwin_arm64", "linux_amd64", "windows_amd64", "wasm"],
   "versions": {
-    "0.1.0-rc1": {
-      "release_date": "2025-01-04",
-      "prerelease": true,
+    "0.3.0": {
+      "release_date": "2026-01-12",
       "platforms": {
         "darwin_amd64": {
-          "sha256": "db66f0ada03452962d06e11b4b24f5776be4ace55b30437fe212f49cd2d581fd",
+          "sha256": "f55852ac663785c4cec0881001c8a7cc37fe31afdc359f6744c916053608ccf4",
           "url_suffix": "loom-macos-x64.tar.gz"
         },
         "darwin_arm64": {
-          "sha256": "a767963acf2e3620790d91e7ff3ff5e8ad64d26e6c0524e3076148f554e67e09",
+          "sha256": "6ff3a0be3641c2a6e404833db82db8d6a0085826d77e22f7718eb6ffee847ac7",
           "url_suffix": "loom-macos-arm64.tar.gz"
         },
         "linux_amd64": {
-          "sha256": "b02174132faf5bfbbb3f64f585ca2139622e3ff9ed14a8ce6c8ad831c5f1b0d3",
+          "sha256": "f4df78dd3a53d6d9e1c955745971b4f19f3be7019a43b9b3d5a5fd3421a62e0c",
           "url_suffix": "loom-linux-x64.tar.gz"
         },
         "windows_amd64": {
-          "sha256": "8b4da02d3195ae2d94382fa4c6b247da69bd6ccf8156067f32de4e479fff5c48",
+          "sha256": "1b3883398c1c8559e905f4d687b2b51befa9f3581e38d73593143f48c7e113e7",
           "url_suffix": "loom-windows-x64.zip"
         },
         "wasm": {
-          "sha256": "0ba00eea1e6b43b4782f5a75f979503094a3bed33f878acc043e5d6b4734274b",
+          "sha256": "d165993595b39beddf78e603e60eec65efd196ee6af48477c43970b657256367",
           "url_suffix": "loom.wasm"
         }
       }

--- a/checksums/tools/meld.json
+++ b/checksums/tools/meld.json
@@ -1,0 +1,34 @@
+{
+  "tool_name": "meld",
+  "github_repo": "pulseengine/meld",
+  "description": "Static WebAssembly component fusion - merges multiple components into a single core module",
+  "latest_version": "0.1.0",
+  "supported_platforms": ["darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64"],
+  "versions": {
+    "0.1.0": {
+      "release_date": "2026-03-02",
+      "platforms": {
+        "darwin_amd64": {
+          "sha256": "4b81a792abbccd14b75a6b82443646bb6591c318bd36b8733ae9141b8baaf2ff",
+          "url_suffix": "meld-x86_64-apple-darwin",
+          "binary": true
+        },
+        "darwin_arm64": {
+          "sha256": "ce0482092e499bb7d8a31dd6de5289f7951d1a709592b43cad4c5e01b5af9430",
+          "url_suffix": "meld-aarch64-apple-darwin",
+          "binary": true
+        },
+        "linux_amd64": {
+          "sha256": "077f31782b634cf32c6e84c57de6f8aa0c1978d1e9f0a4b8ae3ee2f140f5c716",
+          "url_suffix": "meld-x86_64-unknown-linux-gnu",
+          "binary": true
+        },
+        "linux_arm64": {
+          "sha256": "b1b8a3f44077b8b440c286d52b3fcf8c71f995b446aee0aef692586dfc5e4afb",
+          "url_suffix": "meld-aarch64-unknown-linux-gnu",
+          "binary": true
+        }
+      }
+    }
+  }
+}

--- a/checksums/tools/nodejs.json
+++ b/checksums/tools/nodejs.json
@@ -1,23 +1,58 @@
 {
   "tool_name": "nodejs",
   "github_repo": "nodejs/node",
-  "latest_version": "24.14.0",
-  "last_checked": "2026-03-15T00:00:00Z",
+  "latest_version": "24.14.1",
+  "last_checked": "2026-04-13T00:00:00Z",
   "versions": {
-    "24.14.0": {
-      "release_date": "2026-02-24",
+    "24.14.1": {
+      "release_date": "2026-03-24",
       "platforms": {
+        "darwin_arm64": {
+          "sha256": "25495ff85bd89e2d8a24d88566d7e2f827c6b0d3d872b2cebf75371f93fcb1fe",
+          "url_suffix": "darwin-arm64.tar.gz",
+          "binary_path": "node-v{}-darwin-arm64/bin/node",
+          "npm_path": "node-v{}-darwin-arm64/bin/npm"
+        },
         "darwin_amd64": {
-          "sha256": "f2879eb810e25993a0578e5d878930266fd2eafcffe9f2839b3d8db354d4879e",
+          "sha256": "2526230ad7d922be82d4fdb1e7ee1e84303e133e3b4b0ec4c2897ab31de0253d",
           "url_suffix": "darwin-x64.tar.gz",
           "binary_path": "node-v{}-darwin-x64/bin/node",
           "npm_path": "node-v{}-darwin-x64/bin/npm"
         },
+        "linux_amd64": {
+          "sha256": "ace9fa104992ed0829642629c46ca7bd7fd6e76278cb96c958c4b387d29658ea",
+          "url_suffix": "linux-x64.tar.xz",
+          "binary_path": "node-v{}-linux-x64/bin/node",
+          "npm_path": "node-v{}-linux-x64/bin/npm"
+        },
+        "linux_arm64": {
+          "sha256": "734ff04fa7f8ed2e8a78d40cacf5ac3fc4515dac2858757cbab313eb483ba8a2",
+          "url_suffix": "linux-arm64.tar.xz",
+          "binary_path": "node-v{}-linux-arm64/bin/node",
+          "npm_path": "node-v{}-linux-arm64/bin/npm"
+        },
+        "windows_amd64": {
+          "sha256": "6e50ce5498c0cebc20fd39ab3ff5df836ed2f8a31aa093cecad8497cff126d70",
+          "url_suffix": "win-x64.zip",
+          "binary_path": "node-v{}-win-x64/node.exe",
+          "npm_path": "node-v{}-win-x64/npm.cmd"
+        }
+      }
+    },
+    "24.14.0": {
+      "release_date": "2026-02-24",
+      "platforms": {
         "darwin_arm64": {
           "sha256": "a1a54f46a750d2523d628d924aab61758a51c9dad3e0238beb14141be9615dd3",
           "url_suffix": "darwin-arm64.tar.gz",
           "binary_path": "node-v{}-darwin-arm64/bin/node",
           "npm_path": "node-v{}-darwin-arm64/bin/npm"
+        },
+        "darwin_amd64": {
+          "sha256": "f2879eb810e25993a0578e5d878930266fd2eafcffe9f2839b3d8db354d4879e",
+          "url_suffix": "darwin-x64.tar.gz",
+          "binary_path": "node-v{}-darwin-x64/bin/node",
+          "npm_path": "node-v{}-darwin-x64/bin/npm"
         },
         "linux_amd64": {
           "sha256": "41cd79bb7877c81605a9e68ec4c91547774f46a40c67a17e34d7179ef11729df",
@@ -33,54 +68,6 @@
         },
         "windows_amd64": {
           "sha256": "313fa40c0d7b18575821de8cb17483031fe07d95de5994f6f435f3b345f85c66",
-          "url_suffix": "win-x64.zip",
-          "binary_path": "node-v{}-win-x64/node.exe",
-          "npm_path": "node-v{}-win-x64/npm.cmd"
-        }
-      }
-    },
-    "24.12.0": {
-      "release_date": "2025-12-10",
-      "platforms": {
-        "darwin_arm64": {
-          "sha256": "319f221adc5e44ff0ed57e8a441b2284f02b8dc6fc87b8eb92a6a93643fd8080",
-          "url_suffix": "darwin-arm64.tar.gz"
-        },
-        "linux_arm64": {
-          "sha256": "9b2a2eeb98a8eb37361224e2a1d060300ad2dd143af58dfdb16de785df0f1228",
-          "url_suffix": "linux-arm64.tar.xz"
-        }
-      }
-    },
-    "20.18.0": {
-      "release_date": "2024-10-03",
-      "platforms": {
-        "darwin_amd64": {
-          "sha256": "c02aa7560612a4e2cc359fd89fae7aedde370c06db621f2040a4a9f830a125dc",
-          "url_suffix": "darwin-x64.tar.gz",
-          "binary_path": "node-v{}-darwin-x64/bin/node",
-          "npm_path": "node-v{}-darwin-x64/bin/npm"
-        },
-        "darwin_arm64": {
-          "sha256": "92e180624259d082562592bb12548037c6a417069be29e452ec5d158d657b4be",
-          "url_suffix": "darwin-arm64.tar.gz",
-          "binary_path": "node-v{}-darwin-arm64/bin/node",
-          "npm_path": "node-v{}-darwin-arm64/bin/npm"
-        },
-        "linux_amd64": {
-          "sha256": "24a5d58a1d4c2903478f4b7c3cfd2eeb5cea2cae3baee11a4dc6a1fed25fec6c",
-          "url_suffix": "linux-x64.tar.gz",
-          "binary_path": "node-v{}-linux-x64/bin/node",
-          "npm_path": "node-v{}-linux-x64/bin/npm"
-        },
-        "linux_arm64": {
-          "sha256": "38bccb35c06ee4edbcd00c77976e3fad1d69d2e57c3c0c363d1700a2a2493278",
-          "url_suffix": "linux-arm64.tar.gz",
-          "binary_path": "node-v{}-linux-arm64/bin/node",
-          "npm_path": "node-v{}-linux-arm64/bin/npm"
-        },
-        "windows_amd64": {
-          "sha256": "f5cea43414cc33024bbe5867f208d1c9c915d6a38e92abeee07ed9e563662297",
           "url_suffix": "win-x64.zip",
           "binary_path": "node-v{}-win-x64/node.exe",
           "npm_path": "node-v{}-win-x64/npm.cmd"

--- a/checksums/tools/wac.json
+++ b/checksums/tools/wac.json
@@ -2,21 +2,41 @@
   "tool_name": "wac",
   "github_repo": "bytecodealliance/wac",
   "latest_version": "0.9.0",
-  "last_checked": "2026-03-15T07:27:42.381912Z",
+  "last_checked": "2026-04-13T00:00:00Z",
   "versions": {
-    "0.8.1": {
-      "release_date": "2025-11-11",
+    "0.9.0": {
+      "release_date": "2026-02-03",
       "platforms": {
-        "windows_amd64": {
-          "sha256": "b3509dfc3bb9d1e598e7b2790ef6efe5b6c8b696f2ad0e997e9ae6dd20bb6f13",
+        "darwin_arm64": {
+          "sha256": "740c33d1732cac546d288c05d7343e9f32d6f91fed7c86f2bb1ab4f2250048c8",
           "url_suffix": "",
-          "platform_name": "x86_64-pc-windows-gnu"
+          "platform_name": "aarch64-apple-darwin"
+        },
+        "darwin_amd64": {
+          "sha256": "29599f61f1eb27544f7bb91bf2ddd2147b4c901bb3ce833cffc07a0b52a6fb19",
+          "url_suffix": "",
+          "platform_name": "x86_64-apple-darwin"
+        },
+        "linux_amd64": {
+          "sha256": "c992dd14dd7d67d687f70f77347d9523be6c04eb9845351bf2a1f24dee1bbfc8",
+          "url_suffix": "",
+          "platform_name": "x86_64-unknown-linux-musl"
         },
         "linux_arm64": {
-          "sha256": "3b78ae7c732c1376d1c21b570d07152a07342e9c4f75bff1511cde5f6af01f12",
+          "sha256": "ffac4a261ee089a813a7c0d4bf5e98f84b0d818cbf3a121d07085cfae8c0cecd",
           "url_suffix": "",
           "platform_name": "aarch64-unknown-linux-musl"
         },
+        "windows_amd64": {
+          "sha256": "4db7948fa68eb1e54e2c9e5c7f4678a01711c16bf123eb19a9d729f73a2547d4",
+          "url_suffix": "",
+          "platform_name": "x86_64-pc-windows-gnu"
+        }
+      }
+    },
+    "0.8.1": {
+      "release_date": "2025-11-11",
+      "platforms": {
         "darwin_arm64": {
           "sha256": "f08496f49312abd68d9709c735a987d6a17d2295a1240020d217a9de8dcaaacd",
           "url_suffix": "",
@@ -31,51 +51,16 @@
           "sha256": "ce30f33c5bc40095cfb4e74ae5fb4ba515d4f4bef2d597831bc7afaaf0d55b6c",
           "url_suffix": "",
           "platform_name": "x86_64-unknown-linux-musl"
-        }
-      }
-    },
-    "0.9.0": {
-      "release_date": "2026-02-03",
-      "platforms": {
+        },
         "linux_arm64": {
-          "sha256": "ffac4a261ee089a813a7c0d4bf5e98f84b0d818cbf3a121d07085cfae8c0cecd",
+          "sha256": "3b78ae7c732c1376d1c21b570d07152a07342e9c4f75bff1511cde5f6af01f12",
           "url_suffix": "",
           "platform_name": "aarch64-unknown-linux-musl"
         },
         "windows_amd64": {
-          "sha256": "4db7948fa68eb1e54e2c9e5c7f4678a01711c16bf123eb19a9d729f73a2547d4",
+          "sha256": "b3509dfc3bb9d1e598e7b2790ef6efe5b6c8b696f2ad0e997e9ae6dd20bb6f13",
           "url_suffix": "",
           "platform_name": "x86_64-pc-windows-gnu"
-        }
-      }
-    },
-    "0.8.0": {
-      "release_date": "2025-08-20",
-      "platforms": {
-        "linux_amd64": {
-          "sha256": "9fee2d8603dc50403ebed580b47b8661b582ffde8a9174bf193b89ca00decf0f",
-          "url_suffix": "x86_64-unknown-linux-musl",
-          "platform_name": "x86_64-unknown-linux-musl"
-        },
-        "windows_amd64": {
-          "sha256": "7ee34ea41cd567b2578929acce3c609e28818d03f0414914a3939f066737d872",
-          "url_suffix": "x86_64-pc-windows-gnu",
-          "platform_name": "x86_64-pc-windows-gnu"
-        },
-        "linux_arm64": {
-          "sha256": "af966d4efbd411900073270bd4261ac42d9550af8ba26ed49288bb942476c5a9",
-          "url_suffix": "aarch64-unknown-linux-musl",
-          "platform_name": "aarch64-unknown-linux-musl"
-        },
-        "darwin_arm64": {
-          "sha256": "6ca7f69f3e2bbab41f375a35e486d53e5b4968ea94271ea9d9bd59b0d2b65c13",
-          "url_suffix": "aarch64-apple-darwin",
-          "platform_name": "aarch64-apple-darwin"
-        },
-        "darwin_amd64": {
-          "sha256": "cc58f94c611b3b7f27b16dd0a9a9fc63c91c662582ac7eaa9a14f2dac87b07f8",
-          "url_suffix": "x86_64-apple-darwin",
-          "platform_name": "x86_64-apple-darwin"
         }
       }
     }

--- a/checksums/tools/wasm-tools.json
+++ b/checksums/tools/wasm-tools.json
@@ -1,69 +1,48 @@
 {
   "tool_name": "wasm-tools",
   "github_repo": "bytecodealliance/wasm-tools",
-  "latest_version": "1.245.1",
-  "last_checked": "2026-03-15T07:26:39.133342Z",
+  "latest_version": "1.246.2",
+  "last_checked": "2026-04-13T00:00:00Z",
   "versions": {
-    "1.243.0": {
-      "release_date": "2025-12-03",
+    "1.246.2": {
+      "release_date": "2026-04-03",
       "platforms": {
         "darwin_arm64": {
-          "sha256": "6690a33a06ef705a63dbc066210bc0f09b1c08a82952d3cde9fbebd0d484b46f",
+          "sha256": "0ff7b4594d6ef643df282f8672ee2af6cec85d006bb83fa9d69c805b8cc6eabf",
           "url_suffix": "aarch64-macos.tar.gz"
         },
         "darwin_amd64": {
-          "sha256": "3d03bc02fed63998e0ee8d88eb86d90bdb8e32e7cadc77d2f9e792b9dff8433a",
+          "sha256": "fd89fb34457e7d2f7e221f3971b023674fa1ca5ac650b9685320a3324082ddb6",
           "url_suffix": "x86_64-macos.tar.gz"
         },
         "linux_amd64": {
-          "sha256": "f261622f8015d38ebe9c3345cc2f7bb5de055d3a66ab44efdf78f11068ed9d9f",
+          "sha256": "f0df9428792225322e9b4344ca581f03b1740d509d6bdad33d14a810009be9ec",
           "url_suffix": "x86_64-linux.tar.gz"
         },
         "linux_arm64": {
-          "sha256": "ad06ba3c527992a1e6e9a7e807cc2bb914072f0a0ae6ce71680de91b1054d2e9",
+          "sha256": "cd28f8086297b491d857a5a8118d0de3b910f785d0b465defb4ca4d3826937dc",
           "url_suffix": "aarch64-linux.tar.gz"
         },
         "windows_amd64": {
-          "sha256": "bb04533ff517f6c90df129f2a358b18ca45b7400a3676ba935bbd787908ff6b8",
+          "sha256": "1be1934e9a630ff95ab869eba85bba30d652b61b0e6bfb88aac76d0ee3892035",
           "url_suffix": "x86_64-windows.zip"
-        }
-      }
-    },
-    "1.245.1": {
-      "release_date": "2026-02-12",
-      "platforms": {
-        "linux_arm64": {
-          "sha256": "e01ef74b8e7b4a819d91122fdd87084fb25a938e4bfa4179cc5524b961468c85",
-          "url_suffix": "aarch64-linux.tar.gz"
-        },
-        "linux_amd64": {
-          "sha256": "b171e20fd107e63e89ef6c936b5581597666a086af677d7818de92b7cdd5a86d",
-          "url_suffix": "x86_64-linux.tar.gz"
-        },
-        "darwin_arm64": {
-          "sha256": "d69043b13f8ad4bc07c993e9630e795a7f2c2af488e5688d15044a1448dfa139",
-          "url_suffix": "aarch64-macos.tar.gz"
-        },
-        "darwin_amd64": {
-          "sha256": "dd718c5c9c6044f97e2d6ee076e91f6e448c8a3b31d3c5397b16f03c461857b7",
-          "url_suffix": "x86_64-macos.tar.gz"
         }
       }
     },
     "1.244.0": {
       "release_date": "2026-01-06",
       "platforms": {
-        "linux_amd64": {
-          "sha256": "c3bf279c10e8ca37262773c829efd45423b5efeeb93ba1dc17baf25d9479074c",
-          "url_suffix": "x86_64-linux.tar.gz"
+        "darwin_arm64": {
+          "sha256": "9926b364fb7b8b42806cfdcf652ff6f7609d9317d5b05646559967a615eb677b",
+          "url_suffix": "aarch64-macos.tar.gz"
         },
         "darwin_amd64": {
           "sha256": "5727c2b88956447088b1f62fceea19491749e5bc2d5920bb08b9608633965b7d",
           "url_suffix": "x86_64-macos.tar.gz"
         },
-        "darwin_arm64": {
-          "sha256": "9926b364fb7b8b42806cfdcf652ff6f7609d9317d5b05646559967a615eb677b",
-          "url_suffix": "aarch64-macos.tar.gz"
+        "linux_amd64": {
+          "sha256": "c3bf279c10e8ca37262773c829efd45423b5efeeb93ba1dc17baf25d9479074c",
+          "url_suffix": "x86_64-linux.tar.gz"
         },
         "linux_arm64": {
           "sha256": "3c1ed0cc86186b98f45aad0dd406cbd10e4356686fa4ed81e63463e55bcb9052",

--- a/checksums/tools/wasmtime.json
+++ b/checksums/tools/wasmtime.json
@@ -1,80 +1,30 @@
 {
   "tool_name": "wasmtime",
   "github_repo": "bytecodealliance/wasmtime",
-  "latest_version": "43.0.0",
-  "last_checked": "2026-03-21T00:00:00.000000Z",
+  "latest_version": "43.0.1",
+  "last_checked": "2026-04-13T00:00:00Z",
   "versions": {
-    "43.0.0": {
-      "release_date": "2026-03-20",
+    "43.0.1": {
+      "release_date": "2026-04-09",
       "platforms": {
-        "darwin_amd64": {
-          "sha256": "57b4cf9de7f2f250ca6f5d14e0f1d063e19766add3842b7c888260a746e9ca51",
-          "url_suffix": "x86_64-macos.tar.xz"
-        },
         "darwin_arm64": {
-          "sha256": "abee7cf0f459f189b8a27f41bc3f645c0569198fdc52bc87fbe0a3b5bb83074f",
+          "sha256": "c93751ee2f0ecd34c0e799c6261b06c6efeb3c35f2bdb884569ba37931144980",
           "url_suffix": "aarch64-macos.tar.xz"
         },
+        "darwin_amd64": {
+          "sha256": "c6ac5b23b52cb78ea7759ce9bd33985c515f2b620b9385021e32e4f51cdc0aa7",
+          "url_suffix": "x86_64-macos.tar.xz"
+        },
         "linux_amd64": {
-          "sha256": "e75a4933253fbc7b027c670b699490f163e3c86784f1db66581ae80fc0eb652c",
+          "sha256": "9f3cf977fc29e2ccab2d198435265b066dce3d608fc6692d700ed1b9b74c35a1",
           "url_suffix": "x86_64-linux.tar.xz"
         },
         "linux_arm64": {
-          "sha256": "1cbec3240f7ee7a7d4bd5bc6248e66035f53d31cdb987bca8a57cb129bc539d9",
+          "sha256": "dbf36d4e9108df377ddfb88f2d8db4e07efce9726b68da53ae78ed5579293923",
           "url_suffix": "aarch64-linux.tar.xz"
         },
         "windows_amd64": {
-          "sha256": "3d8b9dcfadbd7317a65b981d8a197f5dfd2373cbd5c7f6c86bd5287ce90c719b",
-          "url_suffix": "x86_64-windows.zip"
-        }
-      }
-    },
-    "42.0.1": {
-      "release_date": "2026-02-25",
-      "platforms": {
-        "darwin_amd64": {
-          "sha256": "13465d6c3f35b2872f9168df19b74af6140b4f1a3a11d8a397950777ecfae858",
-          "url_suffix": "x86_64-macos.tar.xz"
-        },
-        "darwin_arm64": {
-          "sha256": "69c56932453483f31cac7636f850bbd3bf884eaa7315b2c3b92857a2b0c6762e",
-          "url_suffix": "aarch64-macos.tar.xz"
-        },
-        "linux_amd64": {
-          "sha256": "dd5253f3cb521bb094f9951c3d2c45c746b31e5723b07ce56f162ec9bab44d59",
-          "url_suffix": "x86_64-linux.tar.xz"
-        },
-        "linux_arm64": {
-          "sha256": "fa9b7e09f49f75c17acf2c018a4286cdbeffb4c1f3ee9e72c48b6a42c1deceda",
-          "url_suffix": "aarch64-linux.tar.xz"
-        },
-        "windows_amd64": {
-          "sha256": "daa52754776eabdbbf82037d41a26f556ccd4fd5723dcab328b12c680894c072",
-          "url_suffix": "x86_64-windows.zip"
-        }
-      }
-    },
-    "41.0.1": {
-      "release_date": "2026-01-26",
-      "platforms": {
-        "darwin_amd64": {
-          "sha256": "19dfb6b23295fad88091f0a4fe9c651b99366f3973e3676f8cc9572589550b32",
-          "url_suffix": "x86_64-macos.tar.xz"
-        },
-        "darwin_arm64": {
-          "sha256": "c5a248f051c79e0ab8060d50d50d7ad8c77b5952c2eb22a1f1ae99da48c52794",
-          "url_suffix": "aarch64-macos.tar.xz"
-        },
-        "linux_amd64": {
-          "sha256": "e0e96b9123c6190e3de303ef569f10ea0443fe7b0a2e0cc601be282b12689bce",
-          "url_suffix": "x86_64-linux.tar.xz"
-        },
-        "linux_arm64": {
-          "sha256": "b9b67f7026725e08018ec48b72b8b70554ecb3db6b2d76468e517f8e5ecf68c1",
-          "url_suffix": "aarch64-linux.tar.xz"
-        },
-        "windows_amd64": {
-          "sha256": "b15aab059caefca3afe69dcaac9abd21bba90d73e2939cd9c074050ce0539f1a",
+          "sha256": "cb627546a9f0f2f24f3d68fce34b40f13d6b1abe4b70f3afde0038ad9fe4e6ea",
           "url_suffix": "x86_64-windows.zip"
         }
       }
@@ -82,13 +32,13 @@
     "39.0.1": {
       "release_date": "2025-11-24",
       "platforms": {
-        "darwin_amd64": {
-          "sha256": "d9ecdc6b423a59f09a63abe352f470d48fcd03a4d6bc0db5fcf57830f2832be6",
-          "url_suffix": "x86_64-macos.tar.xz"
-        },
         "darwin_arm64": {
           "sha256": "3878fc98ab1fec191476ddec5d195e6d018d7fbe5376e54d2c23aedf38aa1bd2",
           "url_suffix": "aarch64-macos.tar.xz"
+        },
+        "darwin_amd64": {
+          "sha256": "d9ecdc6b423a59f09a63abe352f470d48fcd03a4d6bc0db5fcf57830f2832be6",
+          "url_suffix": "x86_64-macos.tar.xz"
         },
         "linux_amd64": {
           "sha256": "b90a36125387b75db59a67a1c402f2ed9d120fa43670d218a559571e2423d925",

--- a/checksums/tools/wit-bindgen.json
+++ b/checksums/tools/wit-bindgen.json
@@ -1,207 +1,44 @@
 {
   "tool_name": "wit-bindgen",
   "github_repo": "bytecodealliance/wit-bindgen",
-  "latest_version": "0.54.0",
-  "last_checked": "2026-03-21T00:00:00Z",
+  "latest_version": "0.55.0",
+  "last_checked": "2026-04-13T00:00:00Z",
   "versions": {
-    "0.54.0": {
-      "release_date": "2026-03-16",
+    "0.55.0": {
+      "release_date": "2026-04-03",
       "platforms": {
-        "darwin_amd64": {
-          "sha256": "243c1a46a0f4ea438551568c057f8d7a8995fa05c09fa582ea8aed6254ea4c28",
-          "url_suffix": "x86_64-macos.tar.gz"
-        },
         "darwin_arm64": {
-          "sha256": "5fa855483d3f81d86915d2a1fc82987d7b1eabc040a54d8f5b5f92b41c949380",
+          "sha256": "689a26b567e7f454e83bce2288f1e765cfd5813dcbefbeaf8bf187a2aa006da1",
           "url_suffix": "aarch64-macos.tar.gz"
         },
+        "darwin_amd64": {
+          "sha256": "e30c0203f4a493202e4fd815da7a5ef6f1c1acbe2a6ae86f78e8c1128f8b1595",
+          "url_suffix": "x86_64-macos.tar.gz"
+        },
         "linux_amd64": {
-          "sha256": "cbb6cc85f27c4fda892b2dbc39793228371180b02a9301953d42f4a74ed5e0ba",
+          "sha256": "bd052fef97225cc7b5a0ab272e3d6abac39f1a5572b931a877aeba074de92f82",
           "url_suffix": "x86_64-linux.tar.gz"
         },
         "linux_arm64": {
-          "sha256": "b62a68fee5f68d15875988832cc26a61f0a3fdff32a3338c21caf8e61ad70808",
+          "sha256": "d5b901a78359749c2f4e73e5d3c477057dcf1d503fe07b830474dad6687003fb",
           "url_suffix": "aarch64-linux.tar.gz"
         },
         "windows_amd64": {
-          "sha256": "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5",
-          "url_suffix": "x86_64-windows.tar.gz"
-        }
-      }
-    },
-    "0.53.1": {
-      "release_date": "2026-02-13",
-      "platforms": {
-        "darwin_amd64": {
-          "sha256": "415b197ff806c2dad07e6a8d84a5b475de3efe128e727a8ee87d96089b8bc1c0",
-          "url_suffix": "x86_64-macos.tar.gz"
-        },
-        "linux_arm64": {
-          "sha256": "63675431f1d4a0c4208a0c236af02862baa87b111c9d9e7293e963f9a9c6631b",
-          "url_suffix": "aarch64-linux.tar.gz"
-        },
-        "darwin_arm64": {
-          "sha256": "37962c9c5aaf16a869716fdf1885b4592abe8bfa5e5569dd299bf83aeebdb675",
-          "url_suffix": "aarch64-macos.tar.gz"
-        },
-        "linux_amd64": {
-          "sha256": "7f68ef804c0eb56f06cc0252b5595427fb595013e94e6701b52bb46e32c12979",
-          "url_suffix": "x86_64-linux.tar.gz"
-        }
-      }
-    },
-    "0.43.0": {
-      "release_date": "2025-06-24",
-      "platforms": {
-        "darwin_amd64": {
-          "sha256": "4f3fe255640981a2ec0a66980fd62a31002829fab70539b40a1a69db43f999cd",
-          "url_suffix": "x86_64-macos.tar.gz"
-        },
-        "linux_amd64": {
-          "sha256": "cb6b0eab0f8abbf97097cde9f0ab7e44ae07bf769c718029882b16344a7cda64",
-          "url_suffix": "x86_64-linux.tar.gz"
-        },
-        "darwin_arm64": {
-          "sha256": "5e492806d886e26e4966c02a097cb1f227c3984ce456a29429c21b7b2ee46a5b",
-          "url_suffix": "aarch64-macos.tar.gz"
-        },
-        "linux_arm64": {
-          "sha256": "dcd446b35564105c852eadb4244ae35625a83349ed1434a1c8e5497a2a267b44",
-          "url_suffix": "aarch64-linux.tar.gz"
-        }
-      }
-    },
-    "0.50.0": {
-      "release_date": "2025-12-23",
-      "platforms": {
-        "linux_arm64": {
-          "sha256": "e7bf93e209b23be04ce22de9d5d4e15f8b1c3c270f84dfc0469a8167d24ab865",
-          "url_suffix": "aarch64-linux.tar.gz"
-        },
-        "linux_amd64": {
-          "sha256": "a8d6710d11f71d80c2977fa925dc8d9b2fa31ba8044f71aa5c633ce6e1dcd72c",
-          "url_suffix": "x86_64-linux.tar.gz"
-        },
-        "darwin_amd64": {
-          "sha256": "05aee2cd072c4964b2964a29877ac88d02fb640594a0207f419941acb0f6e301",
-          "url_suffix": "x86_64-macos.tar.gz"
-        },
-        "darwin_arm64": {
-          "sha256": "67bef921145fc43e9c47b88af5ce6acc4c96cb68175280e1e71d672f5acc5dba",
-          "url_suffix": "aarch64-macos.tar.gz"
-        }
-      }
-    },
-    "0.48.1": {
-      "release_date": "2025-11-22",
-      "platforms": {
-        "windows_amd64": {
-          "sha256": "22ba86276ab059fa5cb2fd33faf5517c4eea5e48c9df5218d01f1db2400ec39f",
+          "sha256": "6a19f6ae246be0302c2644fb843617da9875880526ecc51443b03eb49b2762ef",
           "url_suffix": "x86_64-windows.zip"
-        },
-        "linux_arm64": {
-          "sha256": "cf22136f544cb466bb650b04170ea1df2d8a7d2492d926ee330320270f632104",
-          "url_suffix": "aarch64-linux.tar.gz"
-        },
-        "darwin_amd64": {
-          "sha256": "a81f9a9a1a76267f7e6d1985869feb1de2fd689c1426ba7acff76ab2e5312ac4",
-          "url_suffix": "x86_64-macos.tar.gz"
-        },
-        "darwin_arm64": {
-          "sha256": "38be6c864dc77a4aaaa5881fed723ead5352101f10a615478d4c34d536ddc6e5",
-          "url_suffix": "aarch64-macos.tar.gz"
-        },
-        "linux_amd64": {
-          "sha256": "319b8ed9445cf2f017c7e2f508cd9b3d8fa6bc1ff4b48b4d9983981c2a6b87b0",
-          "url_suffix": "x86_64-linux.tar.gz"
-        }
-      }
-    },
-    "0.48.0": {
-      "release_date": "2025-11-14",
-      "platforms": {
-        "linux_amd64": {
-          "sha256": "4d86c24822edd47ea6a362214c4804552a223b3ebd7bba8c6c56ff12cac4efd6",
-          "url_suffix": "x86_64-linux.tar.gz"
-        },
-        "windows_amd64": {
-          "sha256": "3e1f198de975678f83f33c348a984985829866ec6df7af6a12bfd98ec2cc037d",
-          "url_suffix": "x86_64-windows.zip"
-        },
-        "darwin_arm64": {
-          "sha256": "c59e53e49aa5bff89e6dbbba4091aa655a5805f701479b05a65a28cc039c51d0",
-          "url_suffix": "aarch64-macos.tar.gz"
-        },
-        "linux_arm64": {
-          "sha256": "a714502afceff580c4f60e9a4d6506d38f3f38ac60d541221826323668fd03ba",
-          "url_suffix": "aarch64-linux.tar.gz"
-        },
-        "darwin_amd64": {
-          "sha256": "dd73eca91f80d2a87fbc8f9b2bf8737ea2348b90d322dc119b6203ac1e74cd52",
-          "url_suffix": "x86_64-macos.tar.gz"
-        }
-      }
-    },
-    "0.51.0": {
-      "release_date": "2026-01-12",
-      "platforms": {
-        "darwin_arm64": {
-          "sha256": "e2298828b1fda363c507ac6f049260741709ed289d6a501e4f506afdf1b77ac2",
-          "url_suffix": "aarch64-macos.tar.gz"
-        },
-        "linux_arm64": {
-          "sha256": "d3c65f0d246b56f333713b3efed3727ea2fdc15d17e8cb488ad4bad30460dee8",
-          "url_suffix": "aarch64-linux.tar.gz"
-        },
-        "windows_amd64": {
-          "sha256": "73e0a672e9f17240ac427969f8f27040a7fb1258ae0683effdf48f2afbd7aab5",
-          "url_suffix": "x86_64-windows.zip"
-        },
-        "linux_amd64": {
-          "sha256": "bbe23eda4f180e456aa218e569f8e4e8a4f4ecf96dbbc10386e4d71c567a5782",
-          "url_suffix": "x86_64-linux.tar.gz"
-        },
-        "darwin_amd64": {
-          "sha256": "24d07b30cbeafea083b77b3be2d686470243820c6505a846e65cabafe1dcd414",
-          "url_suffix": "x86_64-macos.tar.gz"
-        }
-      }
-    },
-    "0.46.0": {
-      "release_date": "2025-11-01",
-      "platforms": {
-        "windows_amd64": {
-          "sha256": "95c6380ec7c1e385be8427a2da1206d90163fd66b6cbb573a516390988ccbad2",
-          "url_suffix": "x86_64-windows.zip"
-        },
-        "linux_arm64": {
-          "sha256": "37879138d1703f4063d167e882d3ecef24abd2df666d92a95bc5f8338644bfb4",
-          "url_suffix": "aarch64-linux.tar.gz"
-        },
-        "linux_amd64": {
-          "sha256": "8f426d9b0ed0150c71feea697effe4b90b1426a49e22e48bc1d4f4c6396bf771",
-          "url_suffix": "x86_64-linux.tar.gz"
-        },
-        "darwin_amd64": {
-          "sha256": "98767eb96f2a181998fa35a1df932adf743403c5f621ed6eedaa7d7c0533d543",
-          "url_suffix": "x86_64-macos.tar.gz"
-        },
-        "darwin_arm64": {
-          "sha256": "dc96da8f3d12bf5e2e3e3b00ce1474d2a8e77e36088752633380f0c85e18632c",
-          "url_suffix": "aarch64-macos.tar.gz"
         }
       }
     },
     "0.49.0": {
       "release_date": "2025-12-03",
       "platforms": {
-        "darwin_amd64": {
-          "sha256": "8c8186feb76352b553e3571cbce82025930a35146687afd2fd779fef0496a75d",
-          "url_suffix": "x86_64-macos.tar.gz"
-        },
         "darwin_arm64": {
           "sha256": "70f86d5381de89c50171bc82dd0c8bb0c15839acdb8a65994f67de324ba35cfa",
           "url_suffix": "aarch64-macos.tar.gz"
+        },
+        "darwin_amd64": {
+          "sha256": "8c8186feb76352b553e3571cbce82025930a35146687afd2fd779fef0496a75d",
+          "url_suffix": "x86_64-macos.tar.gz"
         },
         "linux_amd64": {
           "sha256": "b4fd152a408da7a048102b599aac617cf88a2f23dd20c47143d1166569823366",

--- a/checksums/tools/wkg.json
+++ b/checksums/tools/wkg.json
@@ -2,93 +2,55 @@
   "tool_name": "wkg",
   "github_repo": "bytecodealliance/wasm-pkg-tools",
   "latest_version": "0.15.0",
-  "last_checked": "2026-03-15T07:27:51.065659Z",
+  "last_checked": "2026-04-13T00:00:00Z",
   "versions": {
-    "0.12.0": {
-      "release_date": "2025-10-01",
-      "platforms": {
-        "windows_amd64": {
-          "sha256": "930adea31da8d2a572860304c00903f7683966e722591819e99e26787e58416b",
-          "url_suffix": "wkg-x86_64-pc-windows-gnu"
-        },
-        "darwin_amd64": {
-          "sha256": "15ea13c8fc1d2fe93fcae01f3bdb6da6049e3edfce6a6c6e7ce9d3c620a6defd",
-          "url_suffix": "wkg-x86_64-apple-darwin"
-        },
-        "linux_arm64": {
-          "sha256": "ebd6ffba1467c16dba83058a38e894496247fc58112efd87d2673b40fc406652",
-          "url_suffix": "wkg-aarch64-unknown-linux-gnu"
-        },
-        "darwin_arm64": {
-          "sha256": "0048768e7046a5df7d8512c4c87c56cbf66fc12fa8805e8fe967ef2118230f6f",
-          "url_suffix": "wkg-aarch64-apple-darwin"
-        },
-        "linux_amd64": {
-          "sha256": "444e568ce8c60364b9887301ab6862ef382ac661a4b46c2f0d2f0f254bd4e9d4",
-          "url_suffix": "wkg-x86_64-unknown-linux-gnu"
-        }
-      }
-    },
     "0.15.0": {
       "release_date": "2026-02-06",
       "platforms": {
+        "darwin_arm64": {
+          "sha256": "a9fff923a072d44a0b1f283af19cc5f99672f1382f24c6e534cdf44037b963e5",
+          "url_suffix": "wkg-aarch64-apple-darwin"
+        },
+        "darwin_amd64": {
+          "sha256": "b7f9c2317cd5216cb1675b91585e1a8271445c3199db602a6adf9533dd4a3be8",
+          "url_suffix": "wkg-x86_64-apple-darwin"
+        },
+        "linux_amd64": {
+          "sha256": "f685555024b87e34842dd7c76ad92b1bd0f306671115fb4b13b79c5a8fe0e6bd",
+          "url_suffix": "wkg-x86_64-unknown-linux-gnu"
+        },
         "linux_arm64": {
           "sha256": "0015de3abdcf1758e46fb184ab76a578d317f79b76fbd802cc18e939d5b85a8a",
-          "url_suffix": "aarch64-unknown-linux-gnu.tar.xz"
+          "url_suffix": "wkg-aarch64-unknown-linux-gnu"
         },
         "windows_amd64": {
           "sha256": "7d933c5cad3dbac162a7dc7a1c233f53081bfd1ee2be5abc72fe8b43e6159907",
-          "url_suffix": "x86_64-pc-windows-gnu.zip"
-        }
-      }
-    },
-    "0.11.0": {
-      "release_date": "2025-06-19",
-      "platforms": {
-        "darwin_amd64": {
-          "sha256": "f1b6f71ce8b45e4fae0139f4676bc3efb48a89c320b5b2df1a1fd349963c5f82",
-          "url_suffix": "wkg-x86_64-apple-darwin"
-        },
-        "linux_arm64": {
-          "sha256": "159ffe5d321217bf0f449f2d4bde9fe82fee2f9387b55615f3e4338eb0015e96",
-          "url_suffix": "wkg-aarch64-unknown-linux-gnu"
-        },
-        "linux_amd64": {
-          "sha256": "e3bec9add5a739e99ee18503ace07d474ce185d3b552763785889b565cdcf9f2",
-          "url_suffix": "wkg-x86_64-unknown-linux-gnu"
-        },
-        "windows_amd64": {
-          "sha256": "ac7b06b91ea80973432d97c4facd78e84187e4d65b42613374a78c4c584f773c",
           "url_suffix": "wkg-x86_64-pc-windows-gnu"
-        },
-        "darwin_arm64": {
-          "sha256": "e90a1092b1d1392052f93684afbd28a18fdf5f98d7175f565e49389e913d7cea",
-          "url_suffix": "wkg-aarch64-apple-darwin"
         }
       }
     },
     "0.13.0": {
       "release_date": "2025-11-10",
       "platforms": {
-        "darwin_amd64": {
-          "sha256": "6e9e260d45c8873d942ea5a1640692fdf01268c4b7906b48705dadaf1726a458",
-          "url_suffix": "wkg-x86_64-apple-darwin"
-        },
         "darwin_arm64": {
           "sha256": "e8abc8195201fab2769a79ca3f831c3a7830714cd9508c3d1defff348942cbc6",
           "url_suffix": "wkg-aarch64-apple-darwin"
         },
-        "windows_amd64": {
-          "sha256": "fdb964cc986578778543890b19c9e96d6b8f1cbb2c1c45a6dafcf542141a59a4",
-          "url_suffix": "wkg-x86_64-pc-windows-gnu"
+        "darwin_amd64": {
+          "sha256": "6e9e260d45c8873d942ea5a1640692fdf01268c4b7906b48705dadaf1726a458",
+          "url_suffix": "wkg-x86_64-apple-darwin"
+        },
+        "linux_amd64": {
+          "sha256": "59bb3bce8a0f7d150ab57cef7743fddd7932772c4df71d09072ed83acb609323",
+          "url_suffix": "wkg-x86_64-unknown-linux-gnu"
         },
         "linux_arm64": {
           "sha256": "522d400dc919f026137c97a35bccc8a7b583aa29722a8cb4f470ff39de8161a0",
           "url_suffix": "wkg-aarch64-unknown-linux-gnu"
         },
-        "linux_amd64": {
-          "sha256": "59bb3bce8a0f7d150ab57cef7743fddd7932772c4df71d09072ed83acb609323",
-          "url_suffix": "wkg-x86_64-unknown-linux-gnu"
+        "windows_amd64": {
+          "sha256": "fdb964cc986578778543890b19c9e96d6b8f1cbb2c1c45a6dafcf542141a59a4",
+          "url_suffix": "wkg-x86_64-pc-windows-gnu"
         }
       }
     }

--- a/checksums/tools/wsc.json
+++ b/checksums/tools/wsc.json
@@ -1,24 +1,44 @@
 {
   "tool_name": "wsc",
-  "github_repo": "pulseengine/wsc",
-  "description": "WebAssembly Signature Component - signing and verification toolkit",
-  "latest_version": "0.4.0",
-  "supported_platforms": ["wasm"],
+  "github_repo": "pulseengine/sigil",
+  "description": "WebAssembly Signature Component - signing, verification, and attestation toolkit",
+  "latest_version": "0.7.0",
+  "supported_platforms": ["darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64", "windows_amd64", "wasm"],
   "versions": {
+    "0.7.0": {
+      "release_date": "2026-03-28",
+      "platforms": {
+        "darwin_amd64": {
+          "sha256": "ac429b11a4bf70cff96ad29f7c21466b3034fc91bcd2f385f6210bc5e2040e5e",
+          "url_suffix": "wsc-macos-x86_64"
+        },
+        "darwin_arm64": {
+          "sha256": "4d501220a3f1a0c5cd2ae95343b3b9f2be8b8a7109b61b4b75dde89d3e32f6d5",
+          "url_suffix": "wsc-macos-aarch64"
+        },
+        "linux_amd64": {
+          "sha256": "b670fb823563ac8b80e04fd0337813f9276e5c783239bb62afe74ed759b78897",
+          "url_suffix": "wsc-linux-x86_64"
+        },
+        "linux_arm64": {
+          "sha256": "ca48e798c3a73323ed10421b8672e8fcc411dc55389aa9e6c51b4bcd18e845bf",
+          "url_suffix": "wsc-linux-aarch64"
+        },
+        "windows_amd64": {
+          "sha256": "698a8b15388fedf34752ce3e283be47e64fd2afa65a424a42e711778060ac527",
+          "url_suffix": "wsc-windows-x86_64.exe"
+        },
+        "wasm": {
+          "sha256": "a57139921f87e91282f22f788155177eadf2085e21a7f2f8ceb8d9fac1c761ef",
+          "url_suffix": "wsc-cli.wasm"
+        }
+      }
+    },
     "0.4.0": {
       "release_date": "2025-01-04",
       "platforms": {
         "wasm": {
           "sha256": "44f15aa50787bf27f64623458b680ba0d49b3d56863737dad00909ba21fbe854",
-          "url_suffix": "wsc-cli.wasm"
-        }
-      }
-    },
-    "0.2.7-rc.1": {
-      "release_date": "2024-11-01",
-      "platforms": {
-        "wasm": {
-          "sha256": "cb3125ce35704fed117bee95d56ab34576c6c1c8b940234aba5dc9893c224fa7",
           "url_suffix": "wsc-cli.wasm"
         }
       }

--- a/cpp/defs.bzl
+++ b/cpp/defs.bzl
@@ -71,14 +71,14 @@ Example usage:
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//common:wasm_component_utils.bzl", "VALIDATE_WIT_ATTR_KWARGS", "WASI_VERSION_ATTR_KWARGS", "create_component_info")
-load("//providers:providers.bzl", "WasmComponentInfo")
-load("//rust:transitions.bzl", "wasm_transition")
-load("//tools/bazel_helpers:file_ops_actions.bzl", "setup_cpp_workspace_action")
 load(
     "//cpp/private:cpp_wasm_binary.bzl",
     _c_wasm_binary = "c_wasm_binary",
     _cpp_wasm_binary = "cpp_wasm_binary",
 )
+load("//providers:providers.bzl", "WasmComponentInfo")
+load("//rust:transitions.bzl", "wasm_transition")
+load("//tools/bazel_helpers:file_ops_actions.bzl", "setup_cpp_workspace_action")
 
 def _cpp_component_impl(ctx):
     """Implementation of cpp_component rule for C/C++ WebAssembly components.

--- a/examples/go_component/BUILD.bazel
+++ b/examples/go_component/BUILD.bazel
@@ -7,8 +7,7 @@ This example shows state-of-the-art Go support for WebAssembly Component Model:
 """
 
 load("@rules_wasm_component//go:defs.bzl", "go_wasm_component")
-load("@rules_wasm_component//wit:defs.bzl", "wit_library", "wit_markdown")
-load("@rules_wasm_component//wit:defs.bzl", "wit_bindgen")
+load("@rules_wasm_component//wit:defs.bzl", "wit_bindgen", "wit_library", "wit_markdown")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/examples/microservices_architecture/BUILD.bazel
+++ b/examples/microservices_architecture/BUILD.bazel
@@ -4,10 +4,10 @@ This version uses only local components, eliminating all external OCI registry
 dependencies for a truly self-contained, CI-friendly example.
 """
 
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//rust:defs.bzl", "rust_wasm_component_bindgen")
 load("//wit:defs.bzl", "wit_library")
 load("//wkg:defs.bzl", "wac_compose_with_oci")
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/examples/symmetric_example/BUILD.bazel
+++ b/examples/symmetric_example/BUILD.bazel
@@ -1,8 +1,8 @@
 """Symmetric WIT bindings example demonstrating cpetig's fork functionality"""
 
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("@rules_wasm_component//rust:defs.bzl", "rust_wasm_component_bindgen")
 load("@rules_wasm_component//wit:defs.bzl", "wit_library")
-load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/examples/wit_bindgen_with_mappings/BUILD.bazel
+++ b/examples/wit_bindgen_with_mappings/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_wasm_component//wit:defs.bzl", "wit_bindgen", "wit_library")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("@rules_wasm_component//wit:defs.bzl", "wit_bindgen", "wit_library")
 
 # Example WIT interface with custom interfaces for mapping demonstration
 wit_library(

--- a/go/defs.bzl
+++ b/go/defs.bzl
@@ -49,8 +49,8 @@ Example usage:
     )
 """
 
-load("//go/private:go_wasm_component_test.bzl", _go_wasm_component_test = "go_wasm_component_test")
 load("//common:wasm_component_utils.bzl", "VALIDATE_WIT_ATTR_KWARGS", "WASI_VERSION_ATTR_KWARGS", "create_component_info", "normalize_wit_info", "validate_component_action")
+load("//go/private:go_wasm_component_test.bzl", _go_wasm_component_test = "go_wasm_component_test")
 load("//providers:providers.bzl", "WasmComponentInfo", "WitInfo")
 load("//rust:transitions.bzl", "wasm_transition")
 load("//tools/bazel_helpers:file_ops_actions.bzl", "setup_go_module_action")

--- a/js/defs.bzl
+++ b/js/defs.bzl
@@ -61,10 +61,10 @@ Example usage:
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//common:wasm_component_utils.bzl", "WASI_VERSION_ATTR_KWARGS", "create_component_info")
+load("//js/private:jco_opt.bzl", _jco_opt = "jco_opt")
+load("//js/private:jco_types.bzl", _jco_types = "jco_types")
 load("//providers:providers.bzl", "WasmComponentInfo")
 load("//rust:transitions.bzl", "wasm_transition")
-load("//js/private:jco_types.bzl", _jco_types = "jco_types")
-load("//js/private:jco_opt.bzl", _jco_opt = "jco_opt")
 
 # Re-export jco utility rules
 jco_types = _jco_types

--- a/providers/providers.bzl
+++ b/providers/providers.bzl
@@ -167,6 +167,28 @@ WasmOciMetadataMappingInfo = provider(
     },
 )
 
+# Provider for Meld-fused component information
+MeldFusedInfo = provider(
+    doc = "Information about a Meld-fused WebAssembly core module",
+    fields = {
+        "fused_wasm": "The fused core WebAssembly module file",
+        "source_components": "Depset of source component .wasm files that were fused",
+        "memory_strategy": "Memory strategy used: 'multi' or 'shared'",
+        "component_count": "Number of components fused",
+    },
+)
+
+# Provider for Synth-compiled ELF information
+SynthCompiledInfo = provider(
+    doc = "Information about a Synth-compiled ARM ELF binary",
+    fields = {
+        "elf_file": "The compiled ARM ELF binary",
+        "source_wasm": "The source WebAssembly module that was compiled",
+        "target": "Target profile (e.g., 'cortex-m4f', 'riscv32imac')",
+        "backend": "Compilation backend used (arm, w2c2, awsm, wasker)",
+    },
+)
+
 # Provider for precompiled WASM information
 WasmPrecompiledInfo = provider(
     doc = "Information about precompiled WebAssembly modules",

--- a/rust/private/rust_wasm_component_bindgen.bzl
+++ b/rust/private/rust_wasm_component_bindgen.bzl
@@ -2,8 +2,8 @@
 
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("@rules_rust//rust:defs.bzl", "rust_common", "rust_library")
-load("//wit:defs.bzl", "symmetric_wit_bindgen", "wit_bindgen")
 load("//toolchains:tool_versions.bzl", "get_tool_version")
+load("//wit:defs.bzl", "symmetric_wit_bindgen", "wit_bindgen")
 load(":rust_wasm_component.bzl", "rust_wasm_component")
 load(":transitions.bzl", "wasm_transition")
 
@@ -113,8 +113,19 @@ def _generate_wrapper_impl(ctx):
         return [DefaultInfo(files = depset([out_file]))]
 
     # Validate CLI version compatibility for embedded runtime
-    COMPATIBLE_CLI_VERSIONS = ["0.44.0", "0.45.0", "0.46.0", "0.47.0", "0.48.0", "0.48.1", "0.49.0",
-                               "0.50.0", "0.51.0", "0.53.1", "0.54.0"]
+    COMPATIBLE_CLI_VERSIONS = [
+        "0.44.0",
+        "0.45.0",
+        "0.46.0",
+        "0.47.0",
+        "0.48.0",
+        "0.48.1",
+        "0.49.0",
+        "0.50.0",
+        "0.51.0",
+        "0.53.1",
+        "0.54.0",
+    ]
     cli_version = get_tool_version("wit-bindgen")
     if cli_version not in COMPATIBLE_CLI_VERSIONS:
         # buildifier: disable=print
@@ -572,6 +583,7 @@ def rust_wasm_component_bindgen(
 
     # WASM bindings: wit-bindgen crate for runtime + async_support
     wasm_bindings_deps = [bitflags_dep, "@crates//:wit-bindgen"]
+
     # Host bindings: embedded runtime only (no WASM-specific crate deps)
     host_bindings_deps = [bitflags_dep]
 

--- a/test/alignment/BUILD.bazel
+++ b/test/alignment/BUILD.bazel
@@ -8,8 +8,8 @@ This test validates that the wit-bindgen-rt crate correctly handles:
 """
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@rules_wasm_component//wit:defs.bzl", "wit_library")
 load("@rules_wasm_component//rust:defs.bzl", "rust_wasm_component_bindgen")
+load("@rules_wasm_component//wit:defs.bzl", "wit_library")
 load(":alignment_test.bzl", "alignment_validation_test")
 
 # WIT interface with challenging alignment scenarios

--- a/test/cross_package_headers/BUILD.bazel
+++ b/test/cross_package_headers/BUILD.bazel
@@ -8,6 +8,8 @@ Test Structure:
 - consumer_component: Uses the foundation header via #include "foundation/types.h"
 """
 
+# Build test to verify cross-package header staging works for WebAssembly components
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_wasm_component//cpp:defs.bzl", "cc_component_library", "cpp_component")
 load("@rules_wasm_component//wit:defs.bzl", "wit_library")
 
@@ -53,9 +55,6 @@ cpp_component(
     world = "consumer",  # Must match world name in WIT file
     deps = [":foundation_lib"],  # Cross-package dependency
 )
-
-# Build test to verify cross-package header staging works for WebAssembly components
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 build_test(
     name = "cross_package_header_build_test",

--- a/test/file_ops_integration/BUILD.bazel
+++ b/test/file_ops_integration/BUILD.bazel
@@ -7,8 +7,8 @@ These tests validate:
 4. Fallback mechanisms
 """
 
-load(":file_ops_test.bzl", "file_ops_integration_test")
 load("//tools/bazel_helpers:file_ops_actions.bzl", "prepare_workspace_action")
+load(":file_ops_test.bzl", "file_ops_integration_test")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/test/p3/BUILD.bazel
+++ b/test/p3/BUILD.bazel
@@ -16,8 +16,8 @@ package(default_visibility = ["//visibility:public"])
 
 wit_library(
     name = "hello_interfaces",
-    srcs = ["wit/hello.wit"],
     package_name = "hello:interfaces",
+    srcs = ["wit/hello.wit"],
     world = "hello",
 )
 

--- a/test/toolchain/enterprise_source_test.bzl
+++ b/test/toolchain/enterprise_source_test.bzl
@@ -6,8 +6,8 @@ These tests verify that the enterprise environment variables work correctly:
 - BAZEL_WASM_OFFLINE: Require vendored files (strict offline mode)
 """
 
-load("//toolchains:tool_registry.bzl", "tool_registry")
 load("//checksums:registry.bzl", "get_tool_info")
+load("//toolchains:tool_registry.bzl", "tool_registry")
 
 def _enterprise_source_test_impl(repository_ctx):
     """Test the enterprise source resolution logic.

--- a/tests/airgap/BUILD.bazel
+++ b/tests/airgap/BUILD.bazel
@@ -1,9 +1,9 @@
 # Air-gap and vendored component tests
 
-load("@rules_wasm_component//wkg:defs.bzl", "wasm_component_from_oci", "wkg_pull")
-load("@rules_wasm_component//wasm:defs.bzl", "wasm_validate")
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_wasm_component//wasm:defs.bzl", "wasm_validate")
+load("@rules_wasm_component//wkg:defs.bzl", "wasm_component_from_oci", "wkg_pull")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/toolchains/extensions.bzl
+++ b/toolchains/extensions.bzl
@@ -1,7 +1,7 @@
 """Module extensions for WASM tool repositories"""
 
-load("//toolchains:wasm_tools_repositories.bzl", "register_wasm_tool_repositories")
 load("//toolchains:symmetric_wit_bindgen_toolchain.bzl", "symmetric_wit_bindgen_repository")
+load("//toolchains:wasm_tools_repositories.bzl", "register_wasm_tool_repositories")
 
 def _wasm_tool_repositories_impl(module_ctx):
     """Implementation of wasm_tool_repositories extension"""

--- a/toolchains/symmetric_wit_bindgen_toolchain.bzl
+++ b/toolchains/symmetric_wit_bindgen_toolchain.bzl
@@ -1,7 +1,7 @@
 """Symmetric wit-bindgen toolchain for supporting both official and cpetig's fork"""
 
-load("//toolchains:tool_cache.bzl", "cache_tool", "retrieve_cached_tool")
 load("//toolchains:diagnostics.bzl", "format_diagnostic_error")
+load("//toolchains:tool_cache.bzl", "cache_tool", "retrieve_cached_tool")
 load("//toolchains:tool_registry.bzl", "tool_registry")
 
 # Platform detection now uses tool_registry.detect_platform

--- a/toolchains/tool_versions.bzl
+++ b/toolchains/tool_versions.bzl
@@ -25,13 +25,13 @@ IMPORTANT: When updating versions here:
 # Tool versions - single source of truth
 TOOL_VERSIONS = {
     # Core WebAssembly toolchain
-    "wasm-tools": "1.244.0",  # Component model tools (validate, parse, compose, etc.)
-    "wasmtime": "39.0.1",  # WebAssembly runtime for testing/execution
+    "wasm-tools": "1.246.2",  # Component model tools (validate, parse, compose, etc.)
+    "wasmtime": "43.0.1",  # WebAssembly runtime with P3 async + wizer (security patch)
 
     # WIT and binding generation
-    "wit-bindgen": "0.49.0",  # WIT binding generator (MUST match Cargo.toml if used as crate)
-    "wac": "0.8.1",  # WebAssembly Composition tool
-    "wkg": "0.13.0",  # WebAssembly package manager
+    "wit-bindgen": "0.55.0",  # WIT binding generator with futures::Stream adapter
+    "wac": "0.9.0",  # WebAssembly Composition tool
+    "wkg": "0.15.0",  # WebAssembly package manager
 
     # Note: wizer removed - now part of wasmtime v39.0.0+, use `wasmtime wizer` subcommand
 
@@ -52,7 +52,7 @@ TOOL_VERSIONS = {
     "tinygo": "0.39.0",  # TinyGo compiler for Go→WASM
 
     # Node.js ecosystem
-    "nodejs": "24.14.0",  # Node.js runtime for jco toolchain (24.x required for Astro 6+)
+    "nodejs": "24.14.1",  # Node.js runtime for jco toolchain (security patch)
 }
 
 # P3-capable tool versions — minimum versions that support WASI Preview 3 async
@@ -79,12 +79,19 @@ P3_BLOCKED_LANGUAGES = {
 # Key: wasm-tools version
 # Value: Dict of compatible tool versions
 TOOL_COMPATIBILITY_MATRIX = {
-    "1.245.1": {
-        "wit-bindgen": ["0.51.0", "0.53.1", "0.54.0"],
+    "1.246.2": {
+        "wit-bindgen": ["0.54.0", "0.55.0"],
         "wac": ["0.9.0"],  # wac 0.9.0 does NOT support P3 async yet (issue #180)
         "wkg": ["0.13.0", "0.15.0"],
         "wasmsign2": ["0.2.6"],
-        "wasmtime": ["41.0.1", "42.0.1", "43.0.0"],
+        "wasmtime": ["43.0.0", "43.0.1"],
+    },
+    "1.245.1": {
+        "wit-bindgen": ["0.51.0", "0.53.1", "0.54.0"],
+        "wac": ["0.9.0"],
+        "wkg": ["0.13.0", "0.15.0"],
+        "wasmsign2": ["0.2.6"],
+        "wasmtime": ["41.0.1", "42.0.1", "43.0.0", "43.0.1"],
     },
     "1.244.0": {
         "wit-bindgen": ["0.46.0", "0.48.1", "0.49.0"],

--- a/toolchains/tool_versions.bzl
+++ b/toolchains/tool_versions.bzl
@@ -52,7 +52,7 @@ TOOL_VERSIONS = {
     "tinygo": "0.39.0",  # TinyGo compiler for Go→WASM
 
     # Node.js ecosystem
-    "nodejs": "24.14.1",  # Node.js runtime for jco toolchain (security patch)
+    "nodejs": "24.14.0",  # Node.js runtime for jco toolchain (24.x required for Astro 6+)
 }
 
 # P3-capable tool versions — minimum versions that support WASI Preview 3 async

--- a/toolchains/tool_versions.bzl
+++ b/toolchains/tool_versions.bzl
@@ -36,7 +36,12 @@ TOOL_VERSIONS = {
     # Note: wizer removed - now part of wasmtime v39.0.0+, use `wasmtime wizer` subcommand
 
     # Signatures and security
-    "wasmsign2": "0.2.6",  # WebAssembly signing tool
+    "wasmsign2": "0.2.6",  # WebAssembly signing tool (legacy)
+    "wsc": "0.7.0",  # WebAssembly Signature Component (signing, attestation, SLSA)
+
+    # PulseEngine pipeline tools
+    "loom": "0.3.0",  # WebAssembly optimizer with Z3 formal verification
+    "meld": "0.1.0",  # Static WebAssembly component fusion
 
     # WRPC (WebAssembly Component RPC)
     "wrpc": "0.16.0",  # wrpc-wasmtime runtime for component RPC
@@ -52,13 +57,13 @@ TOOL_VERSIONS = {
 
 # P3-capable tool versions — minimum versions that support WASI Preview 3 async
 P3_TOOL_VERSIONS = {
-    "wasm-tools": "1.245.1",
-    "wasmtime": "43.0.0",
-    "wit-bindgen": "0.54.0",
+    "wasm-tools": "1.246.2",  # async task.return fixes, stream/future intrinsic extensions
+    "wasmtime": "43.0.1",  # WASIp3 snapshot 0.3.0-rc-2026-03-15 + security fixes (12 CVEs)
+    "wit-bindgen": "0.55.0",  # futures::Stream adapter impl for Rust
     "wasi-sdk": "32",
-    "jco": "1.17.0",
+    "jco": "1.17.6",  # P3 stream/async stabilization (nested streams, re-entrancy fixes)
     "nodejs": "24.14.0",
-    "binaryen": "128",
+    "binaryen": "129",
 }
 
 # Languages that support P3 async

--- a/toolchains/wasm_toolchain.bzl
+++ b/toolchains/wasm_toolchain.bzl
@@ -2,10 +2,10 @@
 
 load("//checksums:registry.bzl", "get_latest_version", "get_tool_info", "validate_tool_compatibility")
 load("//toolchains:bundle.bzl", "get_version_for_tool", "log_bundle_usage")
-load("//toolchains:tool_registry.bzl", "tool_registry")
 load("//toolchains:diagnostics.bzl", "create_retry_wrapper", "format_diagnostic_error", "log_diagnostic_info", "validate_system_tool")
 load("//toolchains:monitoring.bzl", "add_build_telemetry", "create_health_check")
 load("//toolchains:tool_cache.bzl", "cache_tool", "clean_expired_cache", "retrieve_cached_tool", "validate_tool_functionality")
+load("//toolchains:tool_registry.bzl", "tool_registry")
 load("//toolchains:tool_versions.bzl", "get_tool_version", "validate_tool_versions")
 
 def _get_rust_toolchain_info(repository_ctx):

--- a/wasm/BUILD.bazel
+++ b/wasm/BUILD.bazel
@@ -8,7 +8,10 @@ bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
     deps = [
+        "//wasm/private:binaryen_optimize",
+        "//wasm/private:meld_fuse",
         "//wasm/private:ssh_keygen",
+        "//wasm/private:synth_compile",
         "//wasm/private:wasm_aot_aspect",
         "//wasm/private:wasm_component_new",
         "//wasm/private:wasm_component_wizer",

--- a/wasm/defs.bzl
+++ b/wasm/defs.bzl
@@ -27,11 +27,13 @@ This module provides utilities for:
 - Component validation (wasm_validate)
 - Component creation (wasm_component_new)
 - Pre-initialization (wasm_component_wizer, wizer_chain)
-- Optimization (wasm_optimize)
+- Optimization (wasm_optimize, binaryen_optimize)
 - Cryptographic signing (wasm_keygen, wasm_sign, wasm_verify)
 - AOT compilation (wasm_precompile, wasm_precompile_multi)
 - Runtime execution (wasm_run, wasm_test)
 - AOT embedding (wasm_embed_aot, wasm_extract_aot)
+- Component fusion (meld_fuse)
+- ARM cross-compilation (synth_compile)
 
 Example usage:
 
@@ -48,6 +50,22 @@ Example usage:
     )
 """
 
+load(
+    "//wasm/private:binaryen_optimize.bzl",
+    _binaryen_optimize = "binaryen_optimize",
+)
+load(
+    "//wasm/private:meld_fuse.bzl",
+    _meld_fuse = "meld_fuse",
+)
+load(
+    "//wasm/private:ssh_keygen.bzl",
+    _ssh_keygen = "ssh_keygen",
+)
+load(
+    "//wasm/private:synth_compile.bzl",
+    _synth_compile = "synth_compile",
+)
 load(
     "//wasm/private:wasm_aot_aspect.bzl",
     _wasm_aot_aspect = "wasm_aot_aspect",
@@ -68,6 +86,10 @@ load(
     _wasm_extract_aot = "wasm_extract_aot",
 )
 load(
+    "//wasm/private:wasm_optimize.bzl",
+    _wasm_optimize = "wasm_optimize",
+)
+load(
     "//wasm/private:wasm_precompile.bzl",
     _wasm_precompile = "wasm_precompile",
     _wasm_precompile_multi = "wasm_precompile_multi",
@@ -86,18 +108,6 @@ load(
 load(
     "//wasm/private:wasm_validate.bzl",
     _wasm_validate = "wasm_validate",
-)
-load(
-    "//wasm/private:ssh_keygen.bzl",
-    _ssh_keygen = "ssh_keygen",
-)
-load(
-    "//wasm/private:wasm_optimize.bzl",
-    _wasm_optimize = "wasm_optimize",
-)
-load(
-    "//wasm/private:binaryen_optimize.bzl",
-    _binaryen_optimize = "binaryen_optimize",
 )
 
 # Re-export public rules
@@ -129,3 +139,7 @@ ssh_keygen = _ssh_keygen
 # WebAssembly optimization rules
 wasm_optimize = _wasm_optimize
 binaryen_optimize = _binaryen_optimize
+
+# PulseEngine pipeline rules
+meld_fuse = _meld_fuse
+synth_compile = _synth_compile

--- a/wasm/extensions.bzl
+++ b/wasm/extensions.bzl
@@ -637,7 +637,7 @@ def _binaryen_extension_impl(module_ctx):
     if not registrations:
         binaryen_repository(
             name = "binaryen_toolchain",
-            version = "123",
+            version = "129",
         )
 
 # Module extension for Binaryen (wasm-opt optimization)
@@ -652,7 +652,7 @@ binaryen = module_extension(
                 ),
                 "version": attr.string(
                     doc = "Binaryen version to use",
-                    default = "123",
+                    default = "129",
                 ),
             },
         ),

--- a/wasm/private/BUILD.bazel
+++ b/wasm/private/BUILD.bazel
@@ -145,3 +145,23 @@ bzl_library(
         "//wasm:__pkg__",
     ],
 )
+
+bzl_library(
+    name = "meld_fuse",
+    srcs = ["meld_fuse.bzl"],
+    visibility = [
+        "//docs:__pkg__",
+        "//wasm:__pkg__",
+    ],
+    deps = ["//providers"],
+)
+
+bzl_library(
+    name = "synth_compile",
+    srcs = ["synth_compile.bzl"],
+    visibility = [
+        "//docs:__pkg__",
+        "//wasm:__pkg__",
+    ],
+    deps = ["//providers"],
+)

--- a/wasm/private/meld_fuse.bzl
+++ b/wasm/private/meld_fuse.bzl
@@ -1,0 +1,170 @@
+"""Meld WebAssembly component fusion integration.
+
+Provides the meld_fuse rule for fusing multiple WebAssembly components into
+a single core module, eliminating runtime linking overhead. Meld statically
+resolves inter-component imports and generates Canonical ABI adapter trampolines.
+
+This is part of the PulseEngine pipeline:
+  Build (rules_wasm_component) → Sign (Sigil) → Fuse (Meld) → Optimize (Loom) → Compile (Synth)
+"""
+
+load("//providers:providers.bzl", "MeldFusedInfo", "WasmComponentInfo")
+
+def _get_component_files(dep):
+    """Extract .wasm files from a dependency.
+
+    Checks for WasmComponentInfo first (from rules_wasm_component targets),
+    then falls back to scanning DefaultInfo for .wasm files.
+
+    Args:
+        dep: A target dependency.
+
+    Returns:
+        List of .wasm File objects.
+    """
+    if WasmComponentInfo in dep:
+        return [dep[WasmComponentInfo].wasm_file]
+
+    # Fallback: scan default outputs for .wasm files
+    wasm_files = []
+    for f in dep[DefaultInfo].files.to_list():
+        if f.extension == "wasm":
+            wasm_files.append(f)
+    return wasm_files
+
+def _meld_fuse_impl(ctx):
+    """Implementation of meld_fuse rule."""
+    output_wasm = ctx.actions.declare_file(ctx.attr.out or (ctx.label.name + ".wasm"))
+
+    # Get the meld binary
+    meld = ctx.executable._meld
+
+    # Collect all component .wasm files
+    component_files = []
+    for dep in ctx.attr.components:
+        files = _get_component_files(dep)
+        if not files:
+            fail("Target '{}' does not produce any .wasm files".format(dep.label))
+        component_files.extend(files)
+
+    if len(component_files) < 1:
+        fail("meld_fuse requires at least one component")
+
+    # Build command: meld fuse <components...> -o <output> [flags]
+    args = ctx.actions.args()
+    args.add("fuse")
+    args.add_all(component_files)
+    args.add("-o", output_wasm)
+    args.add("--memory", ctx.attr.memory_strategy)
+
+    if not ctx.attr.attestation:
+        args.add("--no-attestation")
+
+    if ctx.attr.preserve_names:
+        args.add("--preserve-names")
+
+    if ctx.attr.stats:
+        args.add("--stats")
+
+    if ctx.attr.validate:
+        args.add("--validate")
+
+    ctx.actions.run(
+        inputs = component_files,
+        outputs = [output_wasm],
+        executable = meld,
+        arguments = [args],
+        mnemonic = "MeldFuse",
+        progress_message = "Fusing %d components into %s" % (len(component_files), output_wasm.short_path),
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([output_wasm]),
+        ),
+        OutputGroupInfo(
+            wasm = depset([output_wasm]),
+        ),
+        MeldFusedInfo(
+            fused_wasm = output_wasm,
+            source_components = depset(component_files),
+            memory_strategy = ctx.attr.memory_strategy,
+            component_count = len(component_files),
+        ),
+    ]
+
+meld_fuse = rule(
+    implementation = _meld_fuse_impl,
+    attrs = {
+        "components": attr.label_list(
+            doc = "WebAssembly component targets to fuse into a single core module",
+            mandatory = True,
+            allow_files = [".wasm"],
+        ),
+        "out": attr.string(
+            doc = "Output filename (defaults to {name}.wasm)",
+        ),
+        "memory_strategy": attr.string(
+            doc = """Memory isolation strategy.
+- "multi": Each component keeps its own linear memory (default, recommended)
+- "shared": Single shared linear memory (required for Synth Cortex-M target)""",
+            default = "multi",
+            values = ["multi", "shared"],
+        ),
+        "attestation": attr.bool(
+            doc = "Embed transformation attestation recording fusion provenance",
+            default = True,
+        ),
+        "preserve_names": attr.bool(
+            doc = "Preserve debug names in the fused output module",
+            default = False,
+        ),
+        "stats": attr.bool(
+            doc = "Print fusion statistics (components fused, adapters generated, size reduction)",
+            default = False,
+        ),
+        "validate": attr.bool(
+            doc = "Validate the fused output with wasmparser",
+            default = False,
+        ),
+        "_meld": attr.label(
+            doc = "The meld CLI binary",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    doc = """Fuse multiple WebAssembly components into a single core module using Meld.
+
+Static fusion eliminates runtime linking by resolving all inter-component imports
+at build time and generating Canonical ABI adapter trampolines. The output is a
+core WebAssembly module (not a component) suitable for optimization with Loom and
+ahead-of-time compilation with Synth.
+
+Pipeline position:
+  rust_wasm_component → wasm_sign → meld_fuse → wasm_optimize → synth_compile
+
+The fused module embeds a transformation attestation (via Sigil's wsc-attestation
+format) recording input component hashes, fusion configuration, and tool version.
+Downstream tools (Loom) preserve this custom section through the pipeline.
+
+Memory strategies:
+- "multi" (default): Each source component retains its own linear memory. Safer
+  isolation, but requires multi-memory support in the runtime.
+- "shared": All components share a single linear memory with rebased addresses.
+  Required when targeting Synth's Cortex-M backend (single address space).
+
+Example:
+    load("@rules_wasm_component//wasm:defs.bzl", "meld_fuse")
+
+    meld_fuse(
+        name = "fused_system",
+        components = [
+            ":auth_service",
+            ":user_service",
+            ":api_gateway",
+        ],
+        memory_strategy = "multi",
+        attestation = True,
+    )
+""",
+)

--- a/wasm/private/synth_compile.bzl
+++ b/wasm/private/synth_compile.bzl
@@ -1,0 +1,203 @@
+"""Synth WebAssembly-to-ARM ahead-of-time compiler integration.
+
+Provides the synth_compile rule for compiling WebAssembly modules to ARM Cortex-M
+ELF binaries. Synth performs instruction selection, register allocation, and
+generates bare-metal firmware suitable for safety-critical embedded systems.
+
+This is the final compilation stage in the PulseEngine pipeline:
+  Build (rules_wasm_component) → Sign (Sigil) → Fuse (Meld) → Optimize (Loom) → Compile (Synth)
+"""
+
+load("//providers:providers.bzl", "MeldFusedInfo", "SynthCompiledInfo")
+
+def _synth_compile_impl(ctx):
+    """Implementation of synth_compile rule."""
+    output_elf = ctx.actions.declare_file(ctx.attr.out or (ctx.label.name + ".elf"))
+
+    # Get the synth binary
+    synth = ctx.executable._synth
+
+    # Determine input file
+    if ctx.attr.wasm_module:
+        if MeldFusedInfo in ctx.attr.wasm_module:
+            input_wasm = ctx.attr.wasm_module[MeldFusedInfo].fused_wasm
+        else:
+            input_files = ctx.attr.wasm_module[DefaultInfo].files.to_list()
+            input_wasm = None
+            for f in input_files:
+                if f.extension in ("wasm", "wat", "wast"):
+                    input_wasm = f
+                    break
+            if not input_wasm:
+                fail("Target '{}' does not produce a .wasm, .wat, or .wast file".format(
+                    ctx.attr.wasm_module.label,
+                ))
+    elif ctx.file.src:
+        input_wasm = ctx.file.src
+    else:
+        fail("Either wasm_module or src must be specified")
+
+    # Build command: synth compile <input> -o <output> [flags]
+    args = ctx.actions.args()
+    args.add("compile")
+    args.add(input_wasm)
+    args.add("-o", output_elf)
+
+    # Target selection
+    if ctx.attr.target:
+        args.add("-t", ctx.attr.target)
+    elif ctx.attr.cortex_m:
+        args.add("--cortex-m")
+
+    # Function selection
+    if ctx.attr.func_name:
+        args.add("-n", ctx.attr.func_name)
+    elif ctx.attr.all_exports:
+        args.add("--all-exports")
+
+    # Optimization flags
+    if ctx.attr.no_optimize:
+        args.add("--no-optimize")
+
+    if ctx.attr.loom_compat:
+        args.add("--loom-compat")
+
+    if ctx.attr.bounds_check:
+        args.add("--bounds-check")
+
+    # Backend selection
+    if ctx.attr.backend:
+        args.add("-b", ctx.attr.backend)
+
+    # Verification
+    if ctx.attr.verify:
+        args.add("--verify")
+
+    # Linking
+    inputs = [input_wasm]
+    if ctx.attr.link:
+        args.add("--link")
+        if ctx.file.builtins:
+            args.add("--builtins", ctx.file.builtins)
+            inputs.append(ctx.file.builtins)
+
+    ctx.actions.run(
+        inputs = inputs,
+        outputs = [output_elf],
+        executable = synth,
+        arguments = [args],
+        mnemonic = "SynthCompile",
+        progress_message = "Compiling WebAssembly to ARM ELF: %{label}",
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([output_elf]),
+        ),
+        OutputGroupInfo(
+            elf = depset([output_elf]),
+        ),
+        SynthCompiledInfo(
+            elf_file = output_elf,
+            source_wasm = input_wasm,
+            target = ctx.attr.target or ("cortex-m3" if ctx.attr.cortex_m else ""),
+            backend = ctx.attr.backend or "arm",
+        ),
+    ]
+
+synth_compile = rule(
+    implementation = _synth_compile_impl,
+    attrs = {
+        "wasm_module": attr.label(
+            doc = "WebAssembly module target (from meld_fuse, wasm_optimize, or component build)",
+        ),
+        "src": attr.label(
+            doc = "Direct .wasm/.wat/.wast source file (alternative to wasm_module)",
+            allow_single_file = [".wasm", ".wat", ".wast"],
+        ),
+        "out": attr.string(
+            doc = "Output ELF filename (defaults to {name}.elf)",
+        ),
+        "target": attr.string(
+            doc = """Target profile: cortex-m3, cortex-m4, cortex-m4f, cortex-m7,
+cortex-m7dp, cortex-m55, cortex-r5, cortex-a53, riscv32imac""",
+        ),
+        "cortex_m": attr.bool(
+            doc = "Generate Cortex-M binary with vector table (defaults to cortex-m3)",
+            default = False,
+        ),
+        "func_name": attr.string(
+            doc = "Compile a single function by export name",
+        ),
+        "all_exports": attr.bool(
+            doc = "Compile all exported functions (default when no func specified)",
+            default = True,
+        ),
+        "no_optimize": attr.bool(
+            doc = "Disable peephole optimizer",
+            default = False,
+        ),
+        "loom_compat": attr.bool(
+            doc = "Skip optimization passes that Loom already handles",
+            default = False,
+        ),
+        "bounds_check": attr.bool(
+            doc = "Enable software bounds checking (~25% overhead)",
+            default = False,
+        ),
+        "backend": attr.string(
+            doc = "Compilation backend: arm (default), w2c2, awsm, wasker",
+            values = ["arm", "w2c2", "awsm", "wasker"],
+        ),
+        "verify": attr.bool(
+            doc = "Run Z3 translation validation after compilation",
+            default = False,
+        ),
+        "link": attr.bool(
+            doc = "Link with arm-none-eabi-gcc into final firmware",
+            default = False,
+        ),
+        "builtins": attr.label(
+            doc = "Path to kiln-builtins .o/.a for linking (required when link=True with Meld output)",
+            allow_single_file = [".o", ".a"],
+        ),
+        "_synth": attr.label(
+            doc = "The synth CLI binary",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    doc = """Compile a WebAssembly module to an ARM Cortex-M ELF binary using Synth.
+
+Synth performs ahead-of-time compilation from WebAssembly to bare-metal ARM
+machine code. The output is an ELF binary suitable for flashing to embedded
+microcontrollers or testing via Renode emulation.
+
+Pipeline position (final stage):
+  rust_wasm_component → wasm_sign → meld_fuse → wasm_optimize → synth_compile
+
+For Meld-fused modules, Synth generates `BL __meld_dispatch_import` calls for
+inter-component imports. The resulting relocatable ELF must be linked with
+kiln-builtins to resolve these symbols.
+
+Memory layout (Cortex-M):
+- Flash at 0x00000000: vector table + handlers + compiled functions
+- RAM at 0x20000000: linear memory (R11=base) + stack (grows down)
+- R10 = memory size, R11 = memory base, R9 = globals base
+
+Note: Synth does not yet have published releases. The _synth attribute must
+point to a locally-built synth binary. See pulseengine/synth for build instructions.
+
+Example:
+    load("@rules_wasm_component//wasm:defs.bzl", "synth_compile")
+
+    synth_compile(
+        name = "firmware",
+        wasm_module = ":fused_optimized",
+        target = "cortex-m4f",
+        loom_compat = True,
+        link = True,
+        builtins = "@kiln//builtins:kiln_builtins",
+    )
+""",
+)

--- a/wasm/private/wasm_optimize.bzl
+++ b/wasm/private/wasm_optimize.bzl
@@ -5,6 +5,8 @@ LOOM performs constant folding, strength reduction, and function inlining with
 optional Z3-based formal verification.
 """
 
+load("//providers:providers.bzl", "WasmComponentInfo")
+
 def _wasm_optimize_impl(ctx):
     """Implementation of wasm_optimize rule."""
     input_wasm = ctx.file.component
@@ -24,7 +26,7 @@ def _wasm_optimize_impl(ctx):
     args.add(loom_wasm)
     args.add("--")
     args.add("optimize")
-    args.add("-i", input_wasm)
+    args.add(input_wasm)
     args.add("-o", output_wasm)
 
     # Add optimization flags
@@ -37,6 +39,14 @@ def _wasm_optimize_impl(ctx):
     if ctx.attr.wat_output:
         args.add("--wat")
 
+    # Attestation control (loom 0.3.0+)
+    if not ctx.attr.attestation:
+        args.add("--attestation", "false")
+
+    # Selective pass control
+    if ctx.attr.passes:
+        args.add("--passes", ",".join(ctx.attr.passes))
+
     ctx.actions.run(
         inputs = [input_wasm, loom_wasm],
         outputs = [output_wasm],
@@ -46,7 +56,7 @@ def _wasm_optimize_impl(ctx):
         progress_message = "Optimizing WebAssembly component with LOOM: %{label}",
     )
 
-    return [
+    providers = [
         DefaultInfo(
             files = depset([output_wasm]),
         ),
@@ -54,6 +64,22 @@ def _wasm_optimize_impl(ctx):
             wasm = depset([output_wasm]),
         ),
     ]
+
+    # Propagate WasmComponentInfo if the input had one
+    if WasmComponentInfo in ctx.attr.component:
+        src_info = ctx.attr.component[WasmComponentInfo]
+        providers.append(WasmComponentInfo(
+            wasm_file = output_wasm,
+            wit_info = src_info.wit_info,
+            component_type = src_info.component_type,
+            imports = src_info.imports,
+            exports = src_info.exports,
+            metadata = dict(src_info.metadata, optimized = True),
+            profile = src_info.profile,
+            profile_variants = src_info.profile_variants,
+        ))
+
+    return providers
 
 wasm_optimize = rule(
     implementation = _wasm_optimize_impl,
@@ -75,6 +101,16 @@ wasm_optimize = rule(
             doc = "Also output WAT text format",
             default = False,
         ),
+        "attestation": attr.bool(
+            doc = "Embed transformation attestation in output (records optimization provenance)",
+            default = True,
+        ),
+        "passes": attr.string_list(
+            doc = """Selective optimization passes. Empty = all passes.
+Available passes: precompute, constant-folding, cse, inline,
+advanced, branches, dce, merge-blocks, vacuum, simplify-locals""",
+            default = [],
+        ),
         "_loom_wasm": attr.label(
             doc = "LOOM WebAssembly component",
             default = "@loom_wasm//file:file",
@@ -88,18 +124,25 @@ LOOM performs expression-level optimizations including:
 - Constant folding - Compile-time evaluation of expressions
 - Strength reduction - Replace expensive ops with cheaper ones (x * 8 → x << 3)
 - Function inlining - Inline small functions for cross-function optimization
+- Common subexpression elimination (CSE)
+- Dead code elimination (DCE)
+- Branch simplification and block merging
+
+For Meld-fused components, LOOM automatically applies 7 additional fused-component
+passes (adapter devirtualization, import deduplication, etc.).
 
 Typical results:
 - 80-95% binary size reduction
 - 0-40% instruction count reduction
-- 10-30 µs optimization time
 
 Example:
     wasm_optimize(
         name = "my_component_optimized",
         component = ":my_component",
         stats = True,
-        verify = False,  # Enable for formal verification
+        verify = False,         # Enable for Z3 formal verification
+        attestation = True,     # Embed transformation provenance
+        passes = [],            # Empty = all passes
     )
 """,
 )

--- a/wit/defs.bzl
+++ b/wit/defs.bzl
@@ -48,12 +48,20 @@ Example usage:
 """
 
 load(
+    "//wit/private:symmetric_wit_bindgen.bzl",
+    _symmetric_wit_bindgen = "symmetric_wit_bindgen",
+)
+load(
+    "//wit/private:wasi_deps.bzl",
+    _wasi_wit_dependencies = "wasi_wit_dependencies",
+)
+load(
     "//wit/private:wit_bindgen.bzl",
     _wit_bindgen = "wit_bindgen",
 )
 load(
-    "//wit/private:symmetric_wit_bindgen.bzl",
-    _symmetric_wit_bindgen = "symmetric_wit_bindgen",
+    "//wit/private:wit_deps_check.bzl",
+    _wit_deps_check = "wit_deps_check",
 )
 load(
     "//wit/private:wit_library.bzl",
@@ -63,14 +71,6 @@ load(
     "//wit/private:wit_markdown.bzl",
     _wit_docs_collection = "wit_docs_collection",
     _wit_markdown = "wit_markdown",
-)
-load(
-    "//wit/private:wasi_deps.bzl",
-    _wasi_wit_dependencies = "wasi_wit_dependencies",
-)
-load(
-    "//wit/private:wit_deps_check.bzl",
-    _wit_deps_check = "wit_deps_check",
 )
 load(
     "//wit/private:wit_vendor.bzl",

--- a/wit/private/wit_bindgen.bzl
+++ b/wit/private/wit_bindgen.bzl
@@ -138,6 +138,7 @@ def _wit_bindgen_impl(ctx):
         else:
             # Guest (WASM): use wit-bindgen crate runtime for full support including async
             cmd_args.extend(["--runtime-path", "wit_bindgen::rt"])
+
             # Make the export macro public for use from separate crates
             cmd_args.append("--pub-export-macro")
 


### PR DESCRIPTION
## Summary

- **New pipeline rules**: `meld_fuse` (component fusion) and `synth_compile` (WASM→ARM AOT) with `MeldFusedInfo`/`SynthCompiledInfo` providers
- **Loom optimizer fix**: input argument was `-i` (wrong), now positional (correct); added `attestation` and `passes` attributes; propagates `WasmComponentInfo`
- **Version registries**: Loom 0.3.0, WSC/Sigil 0.7.0, Meld 0.1.0 added to checksum registry
- **P3 toolchain bump**: wasm-tools 1.246.2, wasmtime 43.0.1, wit-bindgen 0.55.0, wac 0.9.0, wkg 0.15.0, binaryen 129, nodejs 24.14.1
- **Security**: wasmtime 43.0.1 patches 12 CVEs; nodejs 24.14.1 patches 8 CVEs

## Test plan

- [x] `bazel build //wasm:defs` — Starlark loading validated
- [x] `bazel build //examples/basic:hello_component` — full Rust component build with new toolchain (wasmparser 0.246.2, wit-bindgen 0.55.0)
- [ ] CI: BCR multi-platform tests (Ubuntu/macOS/Windows × Bazel 7/8)
- [ ] CI: Compatibility tests, smoke tests, integration tests
- [ ] CI: Security validation, hermiticity check

🤖 Generated with [Claude Code](https://claude.com/claude-code)