### PR TITLE
fix: correct nodejs 24.14.1 Linux tar.xz checksums; adopt in jco toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -226,7 +226,7 @@ use_repo(node, "nodejs_toolchains")
 jco = use_extension("//wasm:extensions.bzl", "jco")
 jco.register(
     name = "jco",
-    node_version = "24.14.0",
+    node_version = "24.14.1",
     version = "1.4.0",
 )
 use_repo(jco, "jco_toolchain")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -282,7 +282,7 @@
     },
     "//wasm:extensions.bzl%binaryen": {
       "general": {
-        "bzlTransitiveDigest": "iid0bFk+3Miw3H2/qWbZX0LtK9OPTZNsbyiOK5GHEFU=",
+        "bzlTransitiveDigest": "Mf6ahawtbXDwftSeRDvONGvSPgzWSnxGoyKNfpSZcz0=",
         "usagesDigest": "c5GClIZ+xfHSKFn9WL/02Ag7wuihInOMqTGH5CxR/U8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -306,7 +306,7 @@
     },
     "//wasm:extensions.bzl%cpp_component": {
       "general": {
-        "bzlTransitiveDigest": "iid0bFk+3Miw3H2/qWbZX0LtK9OPTZNsbyiOK5GHEFU=",
+        "bzlTransitiveDigest": "Mf6ahawtbXDwftSeRDvONGvSPgzWSnxGoyKNfpSZcz0=",
         "usagesDigest": "6UgLH0voNNqp5nvGAZIPdkqBNHnYJns3D47wtyD/QX4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -331,8 +331,8 @@
     },
     "//wasm:extensions.bzl%jco": {
       "general": {
-        "bzlTransitiveDigest": "iid0bFk+3Miw3H2/qWbZX0LtK9OPTZNsbyiOK5GHEFU=",
-        "usagesDigest": "EBF1KBwpfJ1aAg4N+iBxBkHr3C8kU856a5qUoN79d0s=",
+        "bzlTransitiveDigest": "Mf6ahawtbXDwftSeRDvONGvSPgzWSnxGoyKNfpSZcz0=",
+        "usagesDigest": "MRHYkIS73wv1wYllXhdZBYX6dRIp7VySTL4edmOH2/M=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -341,7 +341,7 @@
             "repoRuleId": "@@//toolchains:jco_toolchain.bzl%jco_toolchain_repository",
             "attributes": {
               "version": "1.4.0",
-              "node_version": "24.14.0"
+              "node_version": "24.14.1"
             }
           }
         },
@@ -356,7 +356,7 @@
     },
     "//wasm:extensions.bzl%meld": {
       "general": {
-        "bzlTransitiveDigest": "iid0bFk+3Miw3H2/qWbZX0LtK9OPTZNsbyiOK5GHEFU=",
+        "bzlTransitiveDigest": "Mf6ahawtbXDwftSeRDvONGvSPgzWSnxGoyKNfpSZcz0=",
         "usagesDigest": "BnGoVHC5IiwLNc8XvxkOniYvo+CFiIGA27V/CaLd4Gw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -380,7 +380,7 @@
     },
     "//wasm:extensions.bzl%tinygo": {
       "general": {
-        "bzlTransitiveDigest": "iid0bFk+3Miw3H2/qWbZX0LtK9OPTZNsbyiOK5GHEFU=",
+        "bzlTransitiveDigest": "Mf6ahawtbXDwftSeRDvONGvSPgzWSnxGoyKNfpSZcz0=",
         "usagesDigest": "esnFdrH+qxI9awhZ/uW4dIkm843wWmTCzO4b1pdmifs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -404,7 +404,7 @@
     },
     "//wasm:extensions.bzl%wasi_sdk": {
       "general": {
-        "bzlTransitiveDigest": "iid0bFk+3Miw3H2/qWbZX0LtK9OPTZNsbyiOK5GHEFU=",
+        "bzlTransitiveDigest": "Mf6ahawtbXDwftSeRDvONGvSPgzWSnxGoyKNfpSZcz0=",
         "usagesDigest": "juzRCJg8/dKfNzkycrcpYBYuXmaqqX3TTt8KL2C78kQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -778,7 +778,7 @@
     },
     "//wasm:extensions.bzl%wasm_toolchain": {
       "general": {
-        "bzlTransitiveDigest": "iid0bFk+3Miw3H2/qWbZX0LtK9OPTZNsbyiOK5GHEFU=",
+        "bzlTransitiveDigest": "Mf6ahawtbXDwftSeRDvONGvSPgzWSnxGoyKNfpSZcz0=",
         "usagesDigest": "XNTBNCoyj6s3okyF8agUT6PMhSUgcjtD7Xu3qTDS5gk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -812,7 +812,7 @@
     },
     "//wasm:extensions.bzl%wasmtime": {
       "general": {
-        "bzlTransitiveDigest": "iid0bFk+3Miw3H2/qWbZX0LtK9OPTZNsbyiOK5GHEFU=",
+        "bzlTransitiveDigest": "Mf6ahawtbXDwftSeRDvONGvSPgzWSnxGoyKNfpSZcz0=",
         "usagesDigest": "W3m1ohl2c96vXpGAao2C6XIl3CGB+kZYZN2+bagGv0M=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -837,7 +837,7 @@
     },
     "//wasm:extensions.bzl%wkg": {
       "general": {
-        "bzlTransitiveDigest": "iid0bFk+3Miw3H2/qWbZX0LtK9OPTZNsbyiOK5GHEFU=",
+        "bzlTransitiveDigest": "Mf6ahawtbXDwftSeRDvONGvSPgzWSnxGoyKNfpSZcz0=",
         "usagesDigest": "ks+Q/IL0nntNP6PabzUcF0ruF4X9hTKhbmck/ueoPTg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/checksums/tools/nodejs.json
+++ b/checksums/tools/nodejs.json
@@ -20,13 +20,13 @@
           "npm_path": "node-v{}-darwin-x64/bin/npm"
         },
         "linux_amd64": {
-          "sha256": "ace9fa104992ed0829642629c46ca7bd7fd6e76278cb96c958c4b387d29658ea",
+          "sha256": "84d38715d449447117d05c3e71acd78daa49d5b1bfa8aacf610303920c3322be",
           "url_suffix": "linux-x64.tar.xz",
           "binary_path": "node-v{}-linux-x64/bin/node",
           "npm_path": "node-v{}-linux-x64/bin/npm"
         },
         "linux_arm64": {
-          "sha256": "734ff04fa7f8ed2e8a78d40cacf5ac3fc4515dac2858757cbab313eb483ba8a2",
+          "sha256": "71e427e28b78846f201d4d5ecc30cb13d1508ca099ef3871889a1256c7d6f67e",
           "url_suffix": "linux-arm64.tar.xz",
           "binary_path": "node-v{}-linux-arm64/bin/node",
           "npm_path": "node-v{}-linux-arm64/bin/npm"

--- a/toolchains/tool_versions.bzl
+++ b/toolchains/tool_versions.bzl
@@ -52,7 +52,7 @@ TOOL_VERSIONS = {
     "tinygo": "0.39.0",  # TinyGo compiler for Go→WASM
 
     # Node.js ecosystem
-    "nodejs": "24.14.0",  # Node.js runtime for jco toolchain (24.x required for Astro 6+)
+    "nodejs": "24.14.1",  # Node.js runtime for jco toolchain (24.x required for Astro 6+)
 }
 
 # P3-capable tool versions — minimum versions that support WASI Preview 3 async
@@ -62,7 +62,7 @@ P3_TOOL_VERSIONS = {
     "wit-bindgen": "0.55.0",  # futures::Stream adapter impl for Rust
     "wasi-sdk": "32",
     "jco": "1.17.6",  # P3 stream/async stabilization (nested streams, re-entrancy fixes)
-    "nodejs": "24.14.0",
+    "nodejs": "24.14.1",
     "binaryen": "129",
 }
 


### PR DESCRIPTION
## Summary

- The `24.14.1` entry in `checksums/tools/nodejs.json` had wrong sha256 values for `linux_amd64` and `linux_arm64` — they pointed at unrelated files rather than the official `node-v24.14.1-linux-{x64,arm64}.tar.xz` tarballs from nodejs.org. darwin and windows entries were already correct.
- Replaced the two bad checksums with authoritative values from https://nodejs.org/dist/v24.14.1/SHASUMS256.txt and verified by pointing the jco toolchain at 24.14.1.

## Before/after

| Platform | Before | After |
|---|---|---|
| `linux_amd64` | `ace9fa10…` | `84d38715…` |
| `linux_arm64` | `734ff04f…` | `71e427e2…` |

## Scope

- `checksums/tools/nodejs.json` — Linux checksums corrected.
- `MODULE.bazel` — `jco.register(node_version = "24.14.1")` now consumes the corrected registry.
- `toolchains/tool_versions.bzl` — `TOOL_VERSIONS["nodejs"]` and `P3_TOOL_VERSIONS["nodejs"]` bumped so everything reading our registry stays consistent.
- Deliberately NOT changed: `node.toolchain(node_version = "24.14.0")` on line 222 of MODULE.bazel. `rules_nodejs` 6.5.0 ships embedded version metadata only up through 22.18.0 and resolves 24.x via URL construction; switching that to 24.14.1 is a separate scope from this registry hygiene fix.

## Test plan

- [x] `bazel fetch @jco_toolchain//...` — downloads node 24.14.1 tarball, extracts cleanly, installs jco 1.4.0
- [x] `bazel build --nobuild //examples/js_component/...` — analyzes clean with the new version
- [ ] CI green across Linux/macOS/Windows (the registry change is exercised by every jco-using test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)