### PR TITLE
ci: migrate light jobs to smithy self-hosted runners

### DIFF
--- a/.github/workflows/bcr-compatibility.yml
+++ b/.github/workflows/bcr-compatibility.yml
@@ -26,6 +26,7 @@ env:
 jobs:
   bcr-hermetic-test:
     name: BCR Hermetic Build Test
+    # Stays on ubuntu-latest: docker run against vendor BCR image (gcr.io/bazel-public/ubuntu2204) untested on smithy podman shim.
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -130,6 +131,7 @@ jobs:
 
   bcr-toolchain-validation:
     name: BCR Toolchain Validation
+    # Stays on ubuntu-latest: docker run against vendor BCR image (gcr.io/bazel-public/ubuntu2204) untested on smithy podman shim.
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -184,6 +186,7 @@ jobs:
 
   bcr-multi-platform-test:
     name: BCR Multi-Platform Test
+    # Stays on ${{ matrix.os }}: matrix is multi-OS (Linux/macOS/Windows) + Bazel; smithy fleet is Linux-only without Bazel.
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     # Run on all PRs and main branch to catch Windows issues early
@@ -241,6 +244,7 @@ jobs:
 
   bcr-incompatible-flags-test:
     name: BCR Incompatible Flags Test
+    # Stays on ubuntu-latest: Bazel not installed on smithy fleet.
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Only run on main branch and manual dispatch
@@ -287,6 +291,7 @@ jobs:
 
   bcr-metadata-validation:
     name: BCR Metadata Validation
+    # Stays on ubuntu-latest: bundled with the BCR test suite; keeping co-located with related Bazel jobs.
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -348,6 +353,7 @@ jobs:
 
   bcr-test-module-validation:
     name: BCR Test Module Validation
+    # Stays on ubuntu-latest: Bazel not installed on smithy fleet.
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -393,6 +399,7 @@ jobs:
 
   bcr-summary:
     name: BCR Test Summary
+    # Stays on ubuntu-latest: bundled summary job for the BCR test suite, keeping co-located.
     runs-on: ubuntu-latest
     needs: [bcr-hermetic-test, bcr-toolchain-validation]
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   lint:
     name: Lint and Format Check
+    # Stays on ubuntu-latest: Bazel (buildifier) not installed on smithy fleet.
     runs-on: ubuntu-latest
 
     steps:
@@ -38,6 +39,7 @@ jobs:
 
   hermiticity-check:
     name: Hermiticity Check
+    # Stays on ubuntu-latest: Bazel not installed on smithy fleet.
     runs-on: ubuntu-latest
     needs: lint
 
@@ -80,6 +82,7 @@ jobs:
 
   test-linux:
     name: Test on ubuntu-latest
+    # Stays on ubuntu-latest: Bazel + service container (registry:2) not supported on smithy fleet.
     runs-on: ubuntu-latest
     needs: [lint, hermiticity-check]
 
@@ -194,6 +197,7 @@ jobs:
 
   test-macos:
     name: Test on macos-latest
+    # Stays on macos-latest: smithy fleet is Linux-only.
     runs-on: macos-latest
     needs: [lint, hermiticity-check]
 
@@ -307,6 +311,7 @@ jobs:
 
   test-windows:
     name: Test on windows-latest
+    # Stays on windows-latest: smithy fleet is Linux-only.
     runs-on: windows-latest
     needs: [lint]
     # Windows CI is currently experimental - failures don't block merges
@@ -363,6 +368,7 @@ jobs:
 
   bcr-docker-test:
     name: BCR Docker Environment Test
+    # Stays on ubuntu-latest: docker run against vendor BCR image (gcr.io/bazel-public/ubuntu2204) untested on smithy podman shim.
     runs-on: ubuntu-latest
     needs: [lint, hermiticity-check]
 
@@ -443,6 +449,7 @@ jobs:
 
   integration:
     name: Integration Tests
+    # Stays on ubuntu-latest: Bazel + sudo apt-get install not supported on smithy fleet.
     runs-on: ubuntu-latest
     needs: [test-linux, test-macos]
 
@@ -535,7 +542,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     needs: [test-linux, test-macos, integration, bcr-docker-test, hermiticity-check]
     if: github.ref == 'refs/heads/main'
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   bazel-build-and-deploy:
+    # Stays on ubuntu-latest: Bazel not installed on smithy fleet.
     runs-on: ubuntu-latest
     # Only run on main branch to prevent accidental deployments
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/integration-examples.yml
+++ b/.github/workflows/integration-examples.yml
@@ -49,7 +49,7 @@ env:
 jobs:
   trigger-integration:
     name: Trigger Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
 
     # This job requires a PAT with repo scope stored as INTEGRATION_TEST_TOKEN
     # If the secret is not configured, the job will be skipped gracefully
@@ -97,6 +97,7 @@ jobs:
   # This doesn't require cross-repo dispatch but duplicates the test logic
   direct-integration-test:
     name: Direct Integration Test
+    # Stays on ubuntu-latest: Bazel + sudo mv install steps not supported on smithy fleet.
     runs-on: ubuntu-latest
     # Only run if we don't have the dispatch token
     # This provides a fallback for forks and repos without the secret

--- a/.github/workflows/production-readiness.yml
+++ b/.github/workflows/production-readiness.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   smoke-tests:
     name: Smoke Tests
+    # Stays on ${{ matrix.os }}: Bazel matrix (Linux + macOS); smithy fleet is Linux-only without Bazel.
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -40,7 +41,7 @@ jobs:
 
   security-validation:
     name: Security Validation
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
 
     steps:
       - uses: actions/checkout@v6
@@ -72,6 +73,7 @@ jobs:
 
   performance-benchmark:
     name: Performance Benchmark
+    # Stays on ubuntu-latest: Bazel not installed on smithy fleet.
     runs-on: ubuntu-latest
 
     steps:
@@ -114,6 +116,7 @@ jobs:
 
   compatibility-matrix:
     name: Compatibility Tests
+    # Stays on ${{ matrix.os }}: Bazel matrix (Linux + macOS); smithy fleet is Linux-only without Bazel.
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -132,7 +135,7 @@ jobs:
 
   production-readiness:
     name: Production Ready ✅
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     needs:
       [
         smoke-tests,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   create_release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     outputs:
       tag_name: ${{ steps.get_tag.outputs.tag_name }}
       release_archive: ${{ steps.create_archive.outputs.archive_name }}

--- a/.github/workflows/weekly-checksum-update.yml
+++ b/.github/workflows/weekly-checksum-update.yml
@@ -34,6 +34,7 @@ env:
 
 jobs:
   checksum-update:
+    # Stays on ubuntu-latest: Bazel + sudo apt-get install not supported on smithy fleet.
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -430,7 +431,7 @@ jobs:
   # Separate job for notification and cleanup
   notify:
     needs: checksum-update
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     if: always()
 
     steps:


### PR DESCRIPTION
## Summary

Migrates 5 small, dependency-free CI jobs in `rules_wasm_component` from GitHub-hosted `ubuntu-latest` to the smithy self-hosted fleet (`light` class, 4 GB MemoryHigh). The remaining 17 jobs stay on hosted runners because they depend on Bazel, `sudo apt-get`, `docker run` against vendor BCR images, or non-Linux platforms — none of which are currently in the smithy toolchains role.

This follows the pulseengine/spar#201 / rivet / kiln / gale migration playbook documented at https://github.com/pulseengine/smithy/blob/main/docs/migration-playbook.md.

## Coverage

### Migrated to `[self-hosted, linux, x64, light]`

| Workflow | Job | Why `light` is enough |
|---|---|---|
| `ci.yml` | `release` | git-cliff + rsync + tar; no compile |
| `integration-examples.yml` | `trigger-integration` | only invokes `peter-evans/repository-dispatch` |
| `production-readiness.yml` | `security-validation` | grep / regex over `toolchains/` |
| `production-readiness.yml` | `production-readiness` | echo-only summary |
| `release.yml` | `create_release` | git-cliff + rsync + tar + GH release upload |
| `weekly-checksum-update.yml` | `notify` | echo-only |

### Stays on hosted (with in-place reason comments)

| Workflow | Job | Reason |
|---|---|---|
| `ci.yml` | `lint` | Bazel (buildifier) |
| `ci.yml` | `hermiticity-check` | Bazel |
| `ci.yml` | `test-linux` | Bazel + service container `registry:2` |
| `ci.yml` | `test-macos` | macOS only |
| `ci.yml` | `test-windows` | Windows only |
| `ci.yml` | `bcr-docker-test` | `docker run` vs vendor BCR image |
| `ci.yml` | `integration` | Bazel + `sudo apt-get` |
| `bcr-compatibility.yml` | all 7 jobs | Bazel + vendor `docker run` + multi-OS matrix |
| `docs-deploy.yml` | `bazel-build-and-deploy` | Bazel |
| `integration-examples.yml` | `direct-integration-test` | Bazel + `sudo mv` install |
| `production-readiness.yml` | `smoke-tests` | Bazel + macOS matrix |
| `production-readiness.yml` | `performance-benchmark` | Bazel |
| `production-readiness.yml` | `compatibility-matrix` | Bazel + macOS matrix |
| `weekly-checksum-update.yml` | `checksum-update` | Bazel + `sudo apt-get install` |

`publish.yml` and `publish-to-bcr.yml` only call the `bazel-contrib/publish-to-bcr` reusable workflow and have no own `runs-on:` to change.

## Workarounds applied

None — the migrated jobs are pure shell / Node and the playbook's standard workarounds (sudo mv, cargo-deny-action, free-disk-space gate, syft `-b` flag) didn't apply. Every kept-hosted job already uses one of these patterns and the comment names which one.

## Test plan

- [ ] PR CI green on `release` (light) — runs only on push to main, so first real exercise will be the next merge to main; pre-merge dry-run is the workflow YAML lint
- [ ] PR CI green on `trigger-integration` (light)
- [ ] PR CI green on `security-validation` (light)
- [ ] PR CI green on `production-readiness` (light)
- [ ] PR CI green on `notify` (light, only fires after `checksum-update`)
- [ ] All hosted jobs unchanged behavior

## Rollback

Revert the merge commit; every change is `runs-on:` only.

## Follow-ups (out of scope here, tracked in smithy)

- Bazel toolchain on smithy would unblock the bulk (~12 jobs) of this repo's CI.
- BCR vendor `docker run` jobs need podman-shim validation against `gcr.io/bazel-public/ubuntu2204`.