### PR TITLE
fix: use ctx.toolchains[] subscript instead of nonexistent .get()

### DIFF
--- a/common/wasm_component_utils.bzl
+++ b/common/wasm_component_utils.bzl
@@ -179,7 +179,7 @@ def validate_component_action(ctx, wasm_file, wit_file = None):
     if not (hasattr(ctx.attr, "validate_wit") and ctx.attr.validate_wit):
         return []
 
-    wasm_toolchain = ctx.toolchains.get("@rules_wasm_component//toolchains:wasm_tools_toolchain_type")
+    wasm_toolchain = ctx.toolchains["@rules_wasm_component//toolchains:wasm_tools_toolchain_type"]
     if not wasm_toolchain:
         return []
 

--- a/wit/private/wit_bindgen.bzl
+++ b/wit/private/wit_bindgen.bzl
@@ -75,7 +75,7 @@ def _wit_bindgen_impl(ctx):
     # Get wit-bindgen tool from appropriate toolchain
     if ctx.attr.language == "go":
         # Check if TinyGo toolchain is available
-        tinygo_toolchain = ctx.toolchains.get("@rules_wasm_component//toolchains:tinygo_toolchain_type")
+        tinygo_toolchain = ctx.toolchains["@rules_wasm_component//toolchains:tinygo_toolchain_type"]
         if not tinygo_toolchain:
             fail("TinyGo toolchain not available. Go WIT binding generation requires TinyGo toolchain.")
         wit_bindgen = tinygo_toolchain.wit_bindgen_go


### PR DESCRIPTION
## Summary

`ToolchainContext` has no `.get()` method — toolchain access is via subscript
(`ctx.toolchains[type]`). Two call sites used `ctx.toolchains.get(...)`, which
fails at the analysis phase with:

```
Error: 'ToolchainContext' value has no field or method 'get'
```

- `common/wasm_component_utils.bzl` — `validate_component_action()`, reached
  whenever a component rule sets `validate_wit = True`
- `wit/private/wit_bindgen.bzl` — the Go binding-generation path

Both now use the `ctx.toolchains[...]` subscript form — matching the
already-correct usage 6 lines below in `wit_bindgen.bzl`.

Introduced in `6bbd9873` (2026-03-22).

## Validation

The previously analysis-failing `//examples/multi_profile` and
`//examples/world_export` targets now **pass analysis**.

Note: those examples still fail later on a **separate, pre-existing**
wit-bindgen world-name mismatch (`World 'sensor' not found in package
'sensor:interfaces@0.1.0'`) — that bug was masked behind this analysis crash
and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)