### PR TITLE
feat: add Nix flake for a reproducible dev environment

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,40 @@
+# Validates the Nix dev environment: the flake evaluates, and Bazel actually
+# builds from inside `nix develop`. This guards against the flake silently
+# rotting when toolchain or module configuration changes.
+name: Nix
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - flake.nix
+      - flake.lock
+      - MODULE.bazel
+      - .bazelversion
+      - .github/workflows/nix.yml
+
+permissions:
+  contents: read
+
+jobs:
+  dev-shell:
+    name: Nix dev shell
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Evaluate the flake
+        run: nix flake check
+
+      # Builds a representative slice (Rust -> WASM component) entirely inside
+      # the dev shell. Proves Bazel runs under Nix and resolves its toolchains.
+      - name: Build inside the dev shell
+        run: nix develop --command bazel build //examples/basic/...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,24 @@ We welcome contributions to the rules_wasm_component project! This document prov
 - **Bazel 7.0+** with bzlmod support
 - **Rust 1.75+** with WASM targets
 
+> The Nix flake below provides all of these pinned — see the next section.
+
+### Reproducible environment with Nix (recommended)
+
+A Nix flake pins the *host* environment Bazel runs inside — Bazel itself
+(via `.bazelversion`), a C/C++ compiler, git, python, and a host Rust
+toolchain. The WebAssembly toolchains are still fetched hermetically by
+Bazel; Nix only guarantees an identical environment around it.
+
+```bash
+nix develop          # enter the dev shell with everything pinned
+bazel build //...    # WASM toolchains download automatically
+```
+
+`flake.lock` pins the exact dependency revisions, so every developer, CI
+runner, and qualification environment gets an identical toolchain. The `Nix`
+CI workflow verifies that `bazel build` succeeds inside the dev shell.
+
 ### Installation
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779102034,
+        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "rules_wasm_component — Bazel rules for WebAssembly components";
+
+  # Nix provides the *host* environment Bazel runs inside (Bazel, a C/C++
+  # compiler, git, python). It deliberately does NOT provide the WebAssembly
+  # toolchains — wasm-tools, wasmtime, tinygo, wasi-sdk, spar, witness, synth
+  # and friends are downloaded hermetically by Bazel itself, pinned by SHA256
+  # in checksums/tools/*.json. The two pinning layers are orthogonal.
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        # `.bazelversion` (8.2.1) is the single source of truth for the Bazel
+        # version. bazelisk reads it and fetches exactly that release, so we
+        # never pin the Bazel version twice. Expose it as `bazel` so the
+        # documented `bazel build //...` invocation works unchanged.
+        bazel = pkgs.writeShellScriptBin "bazel" ''
+          exec ${pkgs.bazelisk}/bin/bazelisk "$@"
+        '';
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          name = "rules_wasm_component";
+
+          packages = with pkgs; [
+            bazel
+            bazelisk
+
+            # Host build prerequisites Bazel itself relies on.
+            git
+            python3
+            cacert
+            coreutils
+
+            # Host Rust toolchain for the standalone cargo projects under
+            # tools/ and tools-builder/ (lockfile maintenance, dependabot-
+            # style updates). The component builds use rules_rust, not this.
+            cargo
+            rustc
+
+            # Convenience tooling for repository workflows.
+            gh
+            jq
+          ];
+
+          shellHook = ''
+            export BAZELISK_HOME="''${BAZELISK_HOME:-$HOME/.cache/bazelisk}"
+            echo "rules_wasm_component dev shell"
+            echo "  Bazel pinned by .bazelversion ($(cat .bazelversion 2>/dev/null || echo '?'))"
+            echo "  Build:  bazel build //..."
+          '';
+        };
+      });
+}


### PR DESCRIPTION
Closes #389.

## Summary

Adds a Nix flake that pins the **host environment Bazel runs inside** —
Bazel itself (via `.bazelversion`), a C/C++ compiler, git, python, and a host
Rust toolchain.

The WebAssembly toolchains (wasm-tools, wasmtime, tinygo, wasi-sdk, spar,
witness, synth, …) are **not** part of the flake — Bazel still fetches those
hermetically, pinned by SHA256 in `checksums/tools/*.json`. The flake closes
the one remaining unpinned layer: "install Bazel somehow." Two orthogonal
pinning systems — Nix for the host env, the JSON registry for WASM tools.

This is the reproducibility groundwork issue #389 asked for, motivated by the
ISO 26262 / DO-178C "reproduce any build on any machine" requirement.

## Changes

- **`flake.nix`** — a `devShell` exposing `bazel` (a thin wrapper over
  `bazelisk`, which honours `.bazelversion` `8.2.1` so the version is never
  pinned twice), a C/C++ compiler, git, python3, `cacert`, and `cargo`/`rustc`
  for the standalone cargo projects under `tools/` and `tools-builder/`.
- **`flake.lock`** — pins `nixpkgs` and `flake-utils` to exact revisions.
- **`.github/workflows/nix.yml`** — CI runs `nix flake check` and
  `bazel build` *inside* the dev shell, so the flake can't silently rot.
- **`CONTRIBUTING.md`** — documents `nix develop`.

## Validation

Locally (macOS / aarch64):
- `nix flake check` → all checks passed
- `nix develop --command bazel build //examples/basic/... //examples/cpp_component/...`
  → **276 actions, 0 errors**

Bazel resolved its toolchains correctly inside the dev shell, including the
C/C++ path (the cc-under-Nix integration point) — the cpp_component build
went through cleanly. The `Nix` CI job cross-checks the same on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)