### PR TITLE
fix(checksums): restore wsc wasm_component platform (unbreaks wasm_signing tree)

### DIFF
--- a/checksums/tools/wsc.json
+++ b/checksums/tools/wsc.json
@@ -3,11 +3,15 @@
   "github_repo": "pulseengine/sigil",
   "description": "WebAssembly Signature Component - signing, verification, and attestation toolkit",
   "latest_version": "0.9.0",
-  "supported_platforms": ["darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64", "windows_amd64"],
+  "supported_platforms": ["darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64", "windows_amd64", "wasm_component"],
   "versions": {
     "0.9.0": {
       "release_date": "2026-05-21",
       "platforms": {
+        "wasm_component": {
+          "sha256": "b40f70180a3c448b2f2fef21f42966c43a6cc11a7d5796db89de7abf969a1ba4",
+          "url_suffix": "wsc-component.wasm"
+        },
         "darwin_amd64": {
           "sha256": "390182be41aeda8165d40103ab10487ea84f9f52b6d3a336d8a59ead9c88da3b",
           "url_suffix": "wsc-macos-x86_64"
@@ -33,6 +37,10 @@
     "0.7.0": {
       "release_date": "2026-03-28",
       "platforms": {
+        "wasm_component": {
+          "sha256": "15efa8033741c4613165ae49b002847df9afcc27af876778884c79aaea4d45b2",
+          "url_suffix": "wsc-component.wasm"
+        },
         "darwin_amd64": {
           "sha256": "ac429b11a4bf70cff96ad29f7c21466b3034fc91bcd2f385f6210bc5e2040e5e",
           "url_suffix": "wsc-macos-x86_64"

--- a/checksums/tools/wsc.json
+++ b/checksums/tools/wsc.json
@@ -8,10 +8,6 @@
     "0.9.0": {
       "release_date": "2026-05-21",
       "platforms": {
-        "wasm_component": {
-          "sha256": "b40f70180a3c448b2f2fef21f42966c43a6cc11a7d5796db89de7abf969a1ba4",
-          "url_suffix": "wsc-component.wasm"
-        },
         "darwin_amd64": {
           "sha256": "390182be41aeda8165d40103ab10487ea84f9f52b6d3a336d8a59ead9c88da3b",
           "url_suffix": "wsc-macos-x86_64"
@@ -38,8 +34,8 @@
       "release_date": "2026-03-28",
       "platforms": {
         "wasm_component": {
-          "sha256": "15efa8033741c4613165ae49b002847df9afcc27af876778884c79aaea4d45b2",
-          "url_suffix": "wsc-component.wasm"
+          "sha256": "a57139921f87e91282f22f788155177eadf2085e21a7f2f8ceb8d9fac1c761ef",
+          "url_suffix": "wsc-cli.wasm"
         },
         "darwin_amd64": {
           "sha256": "ac429b11a4bf70cff96ad29f7c21466b3034fc91bcd2f385f6210bc5e2040e5e",


### PR DESCRIPTION
## Problem (pre-existing breakage on `main`)
`@wasmsign2_cli_wasm` is a `wasm_component_download(tool_name="wsc", version="0.7.0")`, which resolves only the `wasm`/`wasm_component` platform. The wsc bump to per-OS binaries (#471) migrated `checksums/tools/wsc.json` to per-platform binary entries and **dropped the wasm CLI-module entry**, so the fetch fails:

```
Error in fail: Tool 'wsc' version '0.7.0' not found in registry. Check //checksums/tools/wsc.json (tried platforms: wasm, wasm_component)
```

This cascades into analysis failures for `//tools/wasmsign2_wrapper:*` and the entire `//examples/wasm_signing:*` tree on **every PR**. It landed uncaught because the `Test` workflow triggers on `pull_request`, not on `main` pushes.

## Fix
Restore the `wasm_component` platform entry for **0.7.0** (currently pinned), pointing at the **`wsc-cli.wasm`** asset — the WASI CLI module the wrapper executes via `wasmtime run <wasm> <command>`. (Note: `wsc-component.wasm` fetches but is a *component* that `wasmtime run` can't launch as a command module — the wrapper needs the CLI module.) Checksum verified against the authoritative `pulseengine/sigil` `.sha256` sidecar: `a57139921f87e91282f22f788155177eadf2085e21a7f2f8ceb8d9fac1c761ef`.

0.9.0 is intentionally **not** given a wasm entry: it ships only `wsc-component.wasm` (no CLI module), so bumping the pin past 0.7.0 requires the wrapper to handle the component form — tracked in #498.

## Verification
✅ `bazel build //examples/wasm_signing:example_keys` — fetches `wsc-cli.wasm` and **runs** `wasmsign2_wrapper keygen`, generating a key pair. (Verified at the run level, not just the fetch.)

Unblocks the red `Test on {ubuntu,macos}-latest` jobs that also fail on #497. Found during an automated issue-hunt/version-check pass; related to upgrade-tool tracking issue #498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)